### PR TITLE
CacheWriter rewrite based on CacheLoader.

### DIFF
--- a/cache-tests/src/main/java/org/jsr107/tck/integration/BatchPartialSuccessRecordingClassWriter.java
+++ b/cache-tests/src/main/java/org/jsr107/tck/integration/BatchPartialSuccessRecordingClassWriter.java
@@ -1,0 +1,124 @@
+/**
+ *  Copyright 2011 Terracotta, Inc.
+ *  Copyright 2011 Oracle, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+
+package org.jsr107.tck.integration;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.cache.Cache;
+import javax.cache.CacheException;
+
+/**
+ * Simulate Partial Success in batch operations.
+ * Cache mutation for an entry occurs only when write-through succeeds.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+public class BatchPartialSuccessRecordingClassWriter<K, V> extends RecordingCacheWriter<K, V> {
+
+    /**
+     * simulate delete failure at this rate. default is fail every third delete operation.
+     */
+    private int simulatedDeleteFailure = 3;
+
+    /**
+     * simulate write failure at this rate. default is fail every third write operation.
+     */
+    private int simulatedWriteFailure = 3;
+
+    private AtomicInteger numWrite = new AtomicInteger(1);
+    private AtomicInteger numDelete = new AtomicInteger(1);
+
+    public BatchPartialSuccessRecordingClassWriter(int simulatedWriteFailure, int simulatedDeleteFailure) {
+        this.simulatedWriteFailure = simulatedWriteFailure;
+        this.simulatedDeleteFailure = simulatedDeleteFailure;
+    }
+
+    /**
+     * Some implementations may not call writeAll.  So this method fails every {@link #simulatedWriteFailure} times.
+     * @param entry to write
+     * @throws CacheException to simulate partial failure of write-through
+     */
+    public void write(Cache.Entry<? extends K, ? extends V> entry) {
+        if ((numWrite.getAndIncrement() % simulatedWriteFailure) == 0) {
+            throw new CacheException("simulated failure of write entry=[" + entry.getKey() + "," + entry.getValue()
+                                     + "]");
+        } else {
+            super.write(entry);
+        }
+    }
+
+    /**
+     * Some implementations may not call deleteAll.  So this method fails every {@link #simulatedDeleteFailure} times.
+     * @param key to delete
+     * @throws CacheException to simulate partial failure of write-through
+     */
+    public void delete(Object key) {
+        if ((numDelete.getAndIncrement() % simulatedDeleteFailure) == 0) {
+            throw new CacheException("simulated failure of delete(" + key + ")");
+        } else {
+            super.delete(key);
+        }
+    }
+
+    /**
+     * Always partial success.
+     *
+     * Randomly simulate a write failure for one of the entries.
+     * @param entries to write and upon return the entries that have not been written.
+     * @throws CacheException to simulate partial success.
+     */
+    @Override
+    public void writeAll(Collection<Cache.Entry<? extends K, ? extends V>> entries) {
+        Iterator<Cache.Entry<? extends K, ? extends V>> iterator = entries.iterator();
+        while (iterator.hasNext()) {
+            Cache.Entry<? extends K, ? extends V> entry = iterator.next();
+            if ((numWrite.getAndIncrement() % simulatedWriteFailure) == 0) {
+                throw new CacheException("simulated write failure for entry " + entry.getKey() + ","
+                                             + entry.getValue());
+            } else {
+                write(entry);
+                iterator.remove();
+            }
+        }
+    }
+
+    /**
+     * Always partial success.
+     *
+     * Randomly simulate a delete failure for one of the entries.
+     * @param entries to delete
+     * @throws CacheException to simulate partial success.
+     */
+    @Override
+    public void deleteAll(Collection<?> entries) {
+        for (Iterator<?> keys = entries.iterator(); keys.hasNext(); ) {
+            Object key = keys.next();
+            if ((numDelete.getAndIncrement() % simulatedDeleteFailure) == 0) {
+                throw new CacheException("simulated delete failure for key " + key);
+            } else {
+                delete(key);
+                keys.remove();
+            }
+        }
+    }
+}

--- a/cache-tests/src/main/java/org/jsr107/tck/integration/CacheClient.java
+++ b/cache-tests/src/main/java/org/jsr107/tck/integration/CacheClient.java
@@ -1,0 +1,85 @@
+/**
+ *  Copyright 2011 Terracotta, Inc.
+ *  Copyright 2011 Oracle, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jsr107.tck.integration;
+
+
+import org.jsr107.tck.support.Client;
+
+import java.io.Serializable;
+import java.net.InetAddress;
+
+/**
+ * A client-side base class for delegating requests to a server.
+ *
+ * @author Brian Oliver
+ * @author Joe Fialli
+ */
+public class CacheClient implements AutoCloseable, Serializable {
+    /**
+     * The {@link java.net.InetAddress} on which to connect to the {@link CacheLoaderServer}.
+     */
+    protected InetAddress address;
+
+    /**
+     * The port on which to connect to the {@link CacheLoaderServer}.
+     */
+    protected int port;
+
+    /**
+     * The {@link org.jsr107.tck.support.Client} connection to the {@link CacheLoaderServer}.
+     */
+    protected transient Client client;
+
+    protected CacheClient(InetAddress address, int port) {
+        this.address = address;
+        this.port = port;
+        this.client = null;
+    }
+
+    /**
+     * Obtains the internal {@link Client} used to communicate with the
+     * {@link CacheLoaderServer}.  If the {@link Client} is not connected, a
+     * connection will be attempted.
+     *
+     * @return the {@link Client}
+     */
+    protected synchronized Client getClient() {
+        if (client == null) {
+            try {
+                client = new Client(address, port);
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to acquire Client", e);
+            }
+        }
+
+        return client;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public synchronized void close() throws Exception {
+        if (client != null) {
+            try {
+                client.close();
+            } finally {
+                client = null;
+            }
+        }
+    }
+}

--- a/cache-tests/src/main/java/org/jsr107/tck/integration/CacheLoaderClient.java
+++ b/cache-tests/src/main/java/org/jsr107/tck/integration/CacheLoaderClient.java
@@ -16,7 +16,6 @@
  */
 package org.jsr107.tck.integration;
 
-import org.jsr107.tck.support.Client;
 import org.jsr107.tck.support.Operation;
 
 import javax.cache.Cache;
@@ -24,7 +23,6 @@ import javax.cache.integration.CacheLoader;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.io.Serializable;
 import java.net.InetAddress;
 import java.util.HashMap;
 import java.util.Map;
@@ -37,21 +35,7 @@ import java.util.concurrent.ExecutionException;
  * @param <V> the type of values
  * @author Brian Oliver
  */
-public class CacheLoaderClient<K, V> implements CacheLoader<K, V>, AutoCloseable, Serializable {
-  /**
-   * The {@link InetAddress} on which to connect to the {@link CacheLoaderServer}.
-   */
-  private InetAddress address;
-
-  /**
-   * The port on which to connect to the {@link CacheLoaderServer}.
-   */
-  private int port;
-
-  /**
-   * The {@link Client} connection to the {@link CacheLoaderServer}.
-   */
-  private transient Client client;
+public class CacheLoaderClient<K, V> extends CacheClient implements CacheLoader<K, V> {
 
   /**
    * Constructs a {@link CacheLoaderClient}.
@@ -60,43 +44,9 @@ public class CacheLoaderClient<K, V> implements CacheLoader<K, V>, AutoCloseable
    * @param port    the port to which to connect to the {@link CacheLoaderServer}
    */
   public CacheLoaderClient(InetAddress address, int port) {
-    this.address = address;
-    this.port = port;
+    super(address, port);
 
     this.client = null;
-  }
-
-  /**
-   * Obtains the internal {@link Client} used to communicate with the
-   * {@link CacheLoaderServer}.  If the {@link Client} is not connected, a
-   * connection will be attempted.
-   *
-   * @return the {@link Client}
-   */
-  private synchronized Client getClient() {
-    if (client == null) {
-      try {
-        client = new Client(address, port);
-      } catch (Exception e) {
-        throw new RuntimeException("Failed to acquire Client", e);
-      }
-    }
-
-    return client;
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public synchronized void close() throws Exception {
-    if (client != null) {
-      try {
-        client.close();
-      } finally {
-        client = null;
-      }
-    }
   }
 
   @Override
@@ -178,7 +128,7 @@ public class CacheLoaderClient<K, V> implements CacheLoader<K, V>, AutoCloseable
   }
 
   /**
-   * The {@link LoadAllOperation} representing a {@link Cache#loadAll(Iterable, boolean, javax.cache.integration.CompletionListener)}
+   * The {@link LoadAllOperation} representing a {@link Cache#loadAll(java.util.Set, boolean, javax.cache.integration.CompletionListener)}
    * request.
    *
    * @param <K> the type of keys

--- a/cache-tests/src/main/java/org/jsr107/tck/integration/CacheWriterClient.java
+++ b/cache-tests/src/main/java/org/jsr107/tck/integration/CacheWriterClient.java
@@ -1,0 +1,331 @@
+/**
+ *  Copyright 2011 Terracotta, Inc.
+ *  Copyright 2011 Oracle, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+
+package org.jsr107.tck.integration;
+
+import org.jsr107.tck.support.Operation;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import java.net.InetAddress;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import javax.cache.Cache;
+import javax.cache.integration.CacheWriter;
+
+/**
+ * A {@link CacheWriter} that delegates requests to a {@link CacheWriterServer}.
+ *
+ * @param <K> the type of keys
+ * @param <V> the type of values
+ * @author Brian Oliver
+ * @author Joe Fialli
+ */
+public class CacheWriterClient<K, V> extends CacheClient implements CacheWriter<K, V> {
+
+    /**
+     * Constructs a {@link CacheWriterClient}.
+     *
+     * @param address the {@link InetAddress} on which to connect to the {@link CacheWriterServer}
+     * @param port    the port to which to connect to the {@link CacheWriterServer}
+     */
+    public CacheWriterClient(InetAddress address, int port) {
+        super(address, port);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void write(Cache.Entry<? extends K, ? extends V> entry) {
+        getClient().invoke(new WriteOperation<>(entry));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void writeAll(Collection<Cache.Entry<? extends K, ? extends V>> entries) {
+        getClient().invoke(new WriteAllOperation<>(entries));
+    }
+
+    @Override
+    public void delete(Object key) {
+        getClient().invoke(new DeleteOperation<K, V>((K)key));
+
+    }
+
+    @Override
+    public void deleteAll(Collection<?> keys) {
+        getClient().invoke(new DeleteAllOperation<K, V>((Collection<K>) keys));
+    }
+
+    /**
+     * The {@link DeleteAllOperation} representing a {@link CacheWriter#deleteAll(java.util.Collection)}
+     * request.
+     *
+     * @param <K> the type of keys
+     * @param <V> the type of values
+     */
+    private static class DeleteAllOperation<K, V> implements Operation<Map<K, V>> {
+
+        /**
+         * The keys to Delete.
+         */
+        private Collection<? extends K> keys;
+
+        /**
+         * Constructs a {@link DeleteAllOperation}.
+         *
+         * @param keys the keys to Delete
+         */
+        public DeleteAllOperation(Collection<? extends K> keys) {
+            this.keys = keys;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getType() {
+            return "deleteAll";
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Map<K, V> onInvoke(ObjectInputStream ois, ObjectOutputStream oos)
+                throws IOException, ClassNotFoundException, ExecutionException {
+
+            // send the keys to Delete
+            for (K key : keys) {
+                oos.writeObject(key);
+            }
+
+            oos.writeObject(null);
+
+            // check for remote exceptions
+            Object result = ois.readObject();
+            Collection<K> notDeletedKeys;
+
+            if (result instanceof RuntimeException) {
+                notDeletedKeys = (Collection<K>) ois.readObject();
+
+                // Partial Success processsing
+                // returned keys were not able to be deleted.  remove from original keys list.
+                Iterator<? extends K> iter = keys.iterator();
+                while (iter.hasNext()) {
+                    if (!notDeletedKeys.contains(iter.next())) {
+                        iter.remove();
+                    }
+                }
+
+                throw(RuntimeException) result;
+            } else {
+
+                // if no exception then all keys were deleted, remove all these keys to record that they were deleted.
+                keys.clear();
+
+                return null;
+            }
+        }
+    }
+
+
+    /**
+     * The {@link DeleteOperation} representing a {@link CacheWriter#delete(Object)}
+     * request.
+     *
+     * @param <K> the type of keys
+     * @param <V> the type of values
+     */
+    private static class DeleteOperation<K, V> implements Operation<V> {
+
+        /**
+         * The key to Delete.
+         */
+        private K key;
+
+        /**
+         * Constructs a {@link DeleteOperation}.
+         *
+         * @param key the Key to Delete
+         */
+        public DeleteOperation(K key) {
+            this.key = key;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getType() {
+            return "delete";
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public V onInvoke(ObjectInputStream ois, ObjectOutputStream oos) throws IOException, ClassNotFoundException {
+            oos.writeObject(key);
+
+            Object o = ois.readObject();
+
+            if (o instanceof RuntimeException) {
+                throw(RuntimeException) o;
+            } else {
+                return null;
+            }
+        }
+    }
+
+
+    /**
+     * The {@link WriteAllOperation} representing a {@link Cache#putAll(java.util.Map)} )}
+     * request.
+     *
+     * @param <K> the type of keys
+     * @param <V> the type of values
+     */
+    private static class WriteAllOperation<K, V> implements Operation<Map<K, V>> {
+
+        /**
+         * The entries to write.
+         */
+        private Collection<Cache.Entry<? extends K, ? extends V>> entries;
+
+        /**
+         * Constructs a {@link WriteAllOperation}.
+         *
+         * @param entries the entries to write
+         */
+        public WriteAllOperation(Collection<Cache.Entry<? extends K, ? extends V>> entries) {
+            this.entries = entries;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getType() {
+            return "writeAll";
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Map<K, V> onInvoke(ObjectInputStream ois, ObjectOutputStream oos)
+                throws IOException, ClassNotFoundException {
+
+            // send the entries to write
+            for (Cache.Entry<? extends K, ? extends V> entry : entries) {
+                oos.writeObject(entry.getKey());
+                oos.writeObject(entry.getValue());
+            }
+
+            oos.writeObject(null);
+            Object o = ois.readObject();
+
+            if (o instanceof RuntimeException) {
+
+                // Partial Success processsing, read in keys that failed to be written
+                HashSet<K> failedToWriteKeys = new HashSet<>();
+                K key = (K) ois.readObject();
+                while (key != null) {
+                    failedToWriteKeys.add(key);
+                    key = (K) ois.readObject();
+                }
+
+                Iterator<Cache.Entry<? extends K, ? extends V>> iter = entries.iterator();
+                while (iter.hasNext()) {
+                    if (!failedToWriteKeys.contains(iter.next().getKey())) {
+                        iter.remove();
+                    }
+                }
+
+                throw(RuntimeException) o;
+            } else {
+
+                entries.clear();
+
+                return null;
+            }
+        }
+    }
+
+
+    /**
+     * The {@link WriteOperation} representing a {@link CacheWriter#write(javax.cache.Cache.Entry)}
+     * request.
+     *
+     * @param <K> the type of keys
+     * @param <V> the type of values
+     */
+    private static class WriteOperation<K, V> implements Operation<V> {
+
+        /**
+         * The key to load.
+         */
+        private Cache.Entry<? extends K, ? extends V> entry;
+
+        /**
+         * Constructs a {@link WriteOperation}.
+         *
+         * @param entry the entry to write
+         */
+        public WriteOperation(Cache.Entry<? extends K, ? extends V> entry) {
+            this.entry = entry;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getType() {
+            return "write";
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public V onInvoke(ObjectInputStream ois, ObjectOutputStream oos) throws IOException, ClassNotFoundException {
+            oos.writeObject(entry.getKey());
+            oos.writeObject(entry.getValue());
+
+            Object o = ois.readObject();
+
+            if (o instanceof RuntimeException) {
+                throw(RuntimeException) o;
+            } else {
+                return null;
+            }
+        }
+    }
+}

--- a/cache-tests/src/main/java/org/jsr107/tck/integration/CacheWriterServer.java
+++ b/cache-tests/src/main/java/org/jsr107/tck/integration/CacheWriterServer.java
@@ -1,0 +1,299 @@
+/**
+ *  Copyright 2011 Terracotta, Inc.
+ *  Copyright 2011 Oracle, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+
+package org.jsr107.tck.integration;
+
+import org.jsr107.tck.support.OperationHandler;
+import org.jsr107.tck.support.Server;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import java.util.Collection;
+import java.util.HashSet;
+
+import javax.cache.Cache;
+import javax.cache.integration.CacheWriter;
+
+/**
+ * A {@link Server} that handles {@link CacheWriter} requests from a
+ * {@link CacheWriterClient} and delegates them to an underlying {@link CacheWriter}.
+ *
+ * @param <K> the type of keys
+ * @param <V> the type of values
+ * @author Brian Oliver
+ * @author Joe Fialli
+ */
+public class CacheWriterServer<K, V> extends Server {
+
+    /**
+     * The underlying {@link CacheWriter} that will be used to
+     * load entries requested by the {@link CacheWriterClient}s.
+     */
+    private CacheWriter<K, V> cacheWriter;
+
+    /**
+     * Constructs an CacheWriterServer.
+     *
+     * @param port        the port on which to accept {@link CacheWriterClient} requests
+     * @param cacheWriter (optional) the {@link CacheWriter} that will be used to handle
+     *                    client requests
+     */
+    public CacheWriterServer(int port, CacheWriter<K, V> cacheWriter) {
+        super(port);
+
+        // establish the client-server operation handlers
+        addOperationHandler(new WriteOperationHandler());
+        addOperationHandler(new WriteAllOperationHandler());
+        addOperationHandler(new DeleteOperationHandler());
+        addOperationHandler(new DeleteAllOperationHandler());
+
+        this.cacheWriter = cacheWriter;
+    }
+
+    /**
+     * Set the {@link CacheWriter} the {@link CacheWriterServer} should use
+     * from now on.
+     *
+     * @param cacheWriter the {@link CacheWriter}
+     */
+    public void setCacheWriter(CacheWriter<K, V> cacheWriter) {
+        this.cacheWriter = cacheWriter;
+    }
+
+    /**
+     * The {@link OperationHandler} for a {@link CacheWriter#deleteAll(java.util.Collection)}} operation.
+     */
+    public class DeleteAllOperationHandler implements OperationHandler {
+        @Override
+        public String getType() {
+            return "deleteAll";
+        }
+
+        @Override
+        public void onProcess(ObjectInputStream ois, ObjectOutputStream oos)
+                throws IOException, ClassNotFoundException {
+
+            if (cacheWriter == null) {
+                throw new NullPointerException("The cacheWriter for the CacheWriterServer has not be set");
+            } else {
+                HashSet<K> keys = new HashSet<>();
+
+                K key = (K) ois.readObject();
+                while (key != null) {
+                    keys.add(key);
+
+                    key = (K) ois.readObject();
+                }
+
+                try {
+                    cacheWriter.deleteAll(keys);
+                } catch (Exception e) {
+                    oos.writeObject(e);
+                    oos.writeObject(keys);
+
+                    return;
+                }
+
+                oos.writeObject(keys);
+            }
+        }
+    }
+
+
+    /**
+     * The {@link OperationHandler} for a {@link CacheWriter#delete(Object)} operation.
+     */
+    public class DeleteOperationHandler implements OperationHandler {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getType() {
+            return "delete";
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void onProcess(ObjectInputStream ois, ObjectOutputStream oos)
+                throws IOException, ClassNotFoundException {
+            if (cacheWriter == null) {
+                throw new NullPointerException("The cacheWriter for the CacheWriterServer has not be set");
+            } else {
+
+                K key = (K) ois.readObject();
+                try {
+                    cacheWriter.delete(key);
+                } catch (Exception e) {
+                    oos.writeObject(e);
+
+                    return;
+                }
+
+                // successful completion without an exception.
+                oos.writeObject(null);
+            }
+        }
+    }
+
+
+    /**
+     * An implementation of Cache.Entry.
+     * @param <K>
+     * @param <V>
+     */
+    private static class Entry<K, V> implements Cache.Entry<K, V> {
+        private final K key;
+        private final V value;
+
+        public Entry(K key, V value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        @Override
+        public K getKey() {
+            return key;
+        }
+
+        @Override
+        public V getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> clazz) {
+            throw new UnsupportedOperationException("not implemented");
+        }
+    }
+
+
+    /**
+     * The {@link OperationHandler} for a {@link CacheWriter#writeAll(java.util.Collection)}} operation.
+     */
+    public class WriteAllOperationHandler implements OperationHandler {
+        @Override
+        public String getType() {
+            return "writeAll";
+        }
+
+        private Collection<Cache.Entry<? extends K, ? extends V>> readEntries(ObjectInputStream ois)
+                throws IOException, ClassNotFoundException {
+            Collection<Cache.Entry<? extends K, ? extends V>> entrys = new HashSet<Cache.Entry<? extends K,
+                                                                           ? extends V>>();
+
+            K key = (K) ois.readObject();
+            V value = null;
+            if (key != null) {
+                value = (V) ois.readObject();
+            }
+
+            Entry entry = ((key == null) || (value == null))
+                          ? null
+                          : new Entry(key, value);
+            while (entry != null) {
+                entrys.add(entry);
+                key = (K) ois.readObject();
+                value = null;
+
+                if (key != null) {
+                    value = (V) ois.readObject();
+                }
+
+                entry = ((key == null) || (value == null))
+                        ? null
+                        : new Entry(key, value);
+            }
+
+            return entrys;
+        }
+
+        @Override
+        public void onProcess(ObjectInputStream ois, ObjectOutputStream oos)
+                throws IOException, ClassNotFoundException {
+            if (cacheWriter == null) {
+                throw new NullPointerException("The cacheWriter for the CacheWriterServer has not be set");
+            } else {
+                Collection<Cache.Entry<? extends K, ? extends V>> entrys = readEntries(ois);
+                try {
+                    cacheWriter.writeAll(entrys);
+                } catch (Exception e) {
+                    oos.writeObject(e);
+
+                    for (Cache.Entry<? extends K, ? extends V> entry1 : entrys) {
+                        oos.writeObject(entry1.getKey());
+                    }
+
+                    oos.writeObject(null);
+
+                    return;
+                }
+
+                assert(entrys.size() == 0);
+                oos.writeObject(null);
+            }
+        }
+    }
+
+
+    /**
+     * The {@link OperationHandler} for a {@link CacheWriter#write(javax.cache.Cache.Entry)} operation.
+     */
+    public class WriteOperationHandler implements OperationHandler {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getType() {
+            return "write";
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void onProcess(ObjectInputStream ois, ObjectOutputStream oos)
+                throws IOException, ClassNotFoundException {
+            if (cacheWriter == null) {
+                throw new NullPointerException("The cacheWriter for the CacheWriterServer has not be set");
+            } else {
+                final K key = (K) ois.readObject();
+                final V value = (V) ois.readObject();
+                Cache.Entry<K, V> entry = new Entry<>(key, value);
+                try {
+                    if ((key != null) && (value != null)) {
+                        cacheWriter.write(entry);
+                    }
+                } catch (Exception e) {
+                    oos.writeObject(e);
+
+                    return;
+                }
+
+                // successfully completed operation.
+                oos.writeObject(null);
+            }
+        }
+    }
+}

--- a/cache-tests/src/main/java/org/jsr107/tck/integration/FailingCacheWriter.java
+++ b/cache-tests/src/main/java/org/jsr107/tck/integration/FailingCacheWriter.java
@@ -1,0 +1,51 @@
+/**
+ *  Copyright 2011 Terracotta, Inc.
+ *  Copyright 2011 Oracle, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jsr107.tck.integration;
+
+import javax.cache.Cache;
+import javax.cache.integration.CacheWriter;
+import java.util.Collection;
+
+/**
+ * A {@link CacheWriter} implementation that always throws a
+ * {@link UnsupportedOperationException}, regardless of the request.
+ *
+ * @param <K> the type of keys
+ * @param <V> the type of values
+ */
+public class FailingCacheWriter<K,V> implements CacheWriter<K,V> {
+
+    @Override
+    public void write(Cache.Entry<? extends K, ? extends V> entry) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void writeAll(Collection<Cache.Entry<? extends K, ? extends V>> entries) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void delete(Object key) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void deleteAll(Collection<?> keys) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/cache-tests/src/main/java/org/jsr107/tck/integration/RecordingCacheWriter.java
+++ b/cache-tests/src/main/java/org/jsr107/tck/integration/RecordingCacheWriter.java
@@ -1,0 +1,155 @@
+/**
+ *  Copyright 2011 Terracotta, Inc.
+ *  Copyright 2011 Oracle, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jsr107.tck.integration;
+
+import javax.cache.Cache;
+import javax.cache.integration.CacheWriter;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A CacheWriter implementation that records the entries written and deleted from it so
+ * that they may be later asserted.
+ *
+ * @param <K> the type of the keys
+ * @param <V> the type of the values
+ */
+public class RecordingCacheWriter<K, V> implements CacheWriter<K, V> {
+
+    /**
+     * A map of keys to values that have been written.
+     */
+    private ConcurrentHashMap<K, V> map;
+
+
+    /**
+     * A map of keys to values that have been deleted.
+     */
+    private ConcurrentHashMap<K, V> deletedMap;
+
+    /**
+     * The number of writes that have so far occurred.
+     */
+    private AtomicLong writeCount;
+
+    /**
+     * The number of deletes that have so far occurred.
+     */
+    private AtomicLong deleteCount;
+
+    /**
+     * Constructs a RecordingCacheWriter.
+     */
+    public RecordingCacheWriter() {
+        this.map = new ConcurrentHashMap<>();
+        this.deletedMap = new ConcurrentHashMap<>();
+        this.writeCount = new AtomicLong();
+        this.deleteCount = new AtomicLong();
+    }
+
+    @Override
+    public void write(Cache.Entry<? extends K, ? extends V> entry) {
+        map.put(entry.getKey(), entry.getValue());
+        writeCount.incrementAndGet();
+    }
+
+    @Override
+    public void writeAll(Collection<Cache.Entry<? extends K, ? extends V>> entries) {
+        Iterator<Cache.Entry<? extends K, ? extends V>> iterator = entries.iterator();
+        while (iterator.hasNext()) {
+            write(iterator.next());
+            iterator.remove();
+        }
+    }
+
+    @Override
+    public void delete(Object key) {
+        V value = map.remove((K)key);
+        if (value != null) {
+            deletedMap.put((K)key, value);
+        }
+        deleteCount.incrementAndGet();
+    }
+
+    @Override
+    public void deleteAll(Collection<?> entries) {
+        for (Iterator<?> keys = entries.iterator(); keys.hasNext(); ) {
+            delete(keys.next());
+            keys.remove();
+        }
+    }
+
+    /**
+     * Gets the last written value of the specified key
+     *
+     * @param key the key
+     * @return the value last written
+     */
+    public V get(K key) {
+        return map.get(key);
+    }
+
+    /**
+     * Determines if there is a last written value for the specified key
+     *
+     * @param key the key
+     * @return true if there is a last written value
+     */
+    public boolean hasWritten(K key) {
+        return map.containsKey(key);
+    }
+
+    /**
+     * Determines if this key was last deleted
+     *
+     * @param key the key
+     * @return true if there is a last written value
+     */
+    public boolean wasDeleted(K key) {
+        return deletedMap.containsKey(key);
+    }
+
+    /**
+     * Gets the number of writes that have occurred.
+     *
+     * @return the number of writes
+     */
+    public long getWriteCount() {
+        return writeCount.get();
+    }
+
+    /**
+     * Gets the number of deletes that have occurred.
+     *
+     * @return the number of writes
+     */
+    public long getDeleteCount() {
+        return deleteCount.get();
+    }
+
+    /**
+     * Clears the contents of stored values.
+     */
+    public void clear() {
+        map.clear();
+        deletedMap.clear();
+        this.writeCount = new AtomicLong();
+        this.deleteCount = new AtomicLong();
+    }
+}

--- a/cache-tests/src/main/java/org/jsr107/tck/integration/package-info.java
+++ b/cache-tests/src/main/java/org/jsr107/tck/integration/package-info.java
@@ -17,10 +17,10 @@
 
 /**
  This package contains infrastructure so that loaders and writers can send
- information back to the JUnit test whic initiated them so that asserts can
+ information back to the JUnit test which initiated them so that asserts can
  happen.
 
- An instance of {@link CacheLoaderServer} is created in the JUnit test,
+ An instance of {@link CacheLoaderServer} or {@link CacheWriterServer} is created in the JUnit test,
  listening on port 10,000. Loaders create clients which make requests to the
  server for loading or writing.
 

--- a/cache-tests/src/test/java/org/jsr107/tck/integration/CacheLoaderTest.java
+++ b/cache-tests/src/test/java/org/jsr107/tck/integration/CacheLoaderTest.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -573,7 +574,7 @@ public class CacheLoaderTest {
   }
 
   /**
-   * Ensure that {@link Cache#loadAll(Iterable, boolean, javax.cache.integration.CompletionListener)}
+   * Ensure that {@link Cache#loadAll(Set, boolean, javax.cache.integration.CompletionListener)}
    * for a non-existent single value will cause it to be loaded.
    */
   @Test
@@ -600,7 +601,7 @@ public class CacheLoaderTest {
   }
 
   /**
-   * Ensure that {@link Cache#loadAll(Iterable, boolean, javax.cache.integration.CompletionListener)}
+   * Ensure that {@link Cache#loadAll(Set, boolean, javax.cache.integration.CompletionListener)}
    * for an existing single entry will cause it to be reloaded.
    */
   @Test
@@ -633,7 +634,7 @@ public class CacheLoaderTest {
   }
 
   /**
-   * Ensure that {@link Cache#loadAll(Iterable, boolean, javax.cache.integration.CompletionListener)}
+   * Ensure that {@link Cache#loadAll(Set, boolean, javax.cache.integration.CompletionListener)} )}
    * for multiple non-existing entries will be loaded.
    */
   @Test
@@ -667,7 +668,7 @@ public class CacheLoaderTest {
   }
 
   /**
-   * Ensure that {@link Cache#loadAll(Iterable, boolean, javax.cache.integration.CompletionListener)}
+   * Ensure that {@link Cache#loadAll(Set, boolean, javax.cache.integration.CompletionListener)}
    * for multiple existing entries will be reloaded.
    */
   @Test
@@ -704,7 +705,7 @@ public class CacheLoaderTest {
   }
 
   /**
-   * Ensure that {@link Cache#loadAll(Iterable, boolean, javax.cache.integration.CompletionListener)}
+   * Ensure that {@link Cache#loadAll(Set, boolean, javax.cache.integration.CompletionListener)}
    * won't load <code>null</code> values.
    */
   @Test
@@ -732,7 +733,7 @@ public class CacheLoaderTest {
   }
 
   /**
-   * Ensure that {@link Cache#loadAll(Iterable, boolean, javax.cache.integration.CompletionListener)}
+   * Ensure that {@link Cache#loadAll(java.util.Set, boolean, javax.cache.integration.CompletionListener)}
    * won't load <code>null</code> entries.
    */
   @Test
@@ -760,7 +761,7 @@ public class CacheLoaderTest {
   }
 
   /**
-   * Ensure that {@link Cache#loadAll(Iterable, boolean, javax.cache.integration.CompletionListener)}
+   * Ensure that {@link Cache#loadAll(java.util.Set, boolean, javax.cache.integration.CompletionListener)} )}
    * using a <code>null</code> key will raise an exception
    */
   @Test
@@ -784,7 +785,7 @@ public class CacheLoaderTest {
   }
 
   /**
-   * Ensure that {@link Cache#loadAll(Iterable, boolean, javax.cache.integration.CompletionListener)}
+   * Ensure that {@link Cache#loadAll(java.util.Set, boolean, javax.cache.integration.CompletionListener)}
    * using a <code>null</code> key will raise an exception
    */
   @Test
@@ -824,7 +825,7 @@ public class CacheLoaderTest {
   }
 
   /**
-   * Ensure that {@link Cache#loadAll(Iterable, boolean, javax.cache.integration.CompletionListener)}
+   * Ensure that {@link Cache#loadAll(java.util.Set, boolean, javax.cache.integration.CompletionListener)}  )}
    * will propagate an exception from a {@link CacheLoader}.
    */
   @Test

--- a/cache-tests/src/test/java/org/jsr107/tck/integration/CacheWriterClientServerTest.java
+++ b/cache-tests/src/test/java/org/jsr107/tck/integration/CacheWriterClientServerTest.java
@@ -1,0 +1,144 @@
+package org.jsr107.tck.integration;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+
+import static org.junit.Assert.fail;
+
+import javax.cache.Cache;
+
+/**
+ * Functional Tests for the {@link CacheWriterClient} and {@link CacheWriterServer}
+ * classes.
+ *
+ * @author Joe Fialli
+ */
+public class CacheWriterClientServerTest {
+
+    /**
+     * Ensure that entry can be written from the {@link CacheWriterClient} via
+     * the {@link CacheWriterServer}.
+     */
+    @Test
+    public void shouldWriteFromServerWithClient() {
+
+        RecordingCacheWriter<String, String> recordingCacheWriter = new RecordingCacheWriter<>();
+
+        CacheWriterServer<String, String> serverCacheWriter = new CacheWriterServer<>(10000,
+                                                                  recordingCacheWriter);
+
+        try {
+            serverCacheWriter.open();
+
+            CacheWriterClient<String, String> clientCacheWriter =
+                new CacheWriterClient<>(serverCacheWriter.getInetAddress(), 10000);
+            Cache.Entry<String, String> entry = new Entry<>("hello", "gudday");
+            clientCacheWriter.write(entry);
+            String writtenValue = recordingCacheWriter.get("hello");
+
+            Assert.assertThat(writtenValue, is(notNullValue()));
+            Assert.assertThat(writtenValue, is("gudday"));
+            Assert.assertThat(recordingCacheWriter.hasWritten("hello"), is(true));
+        } catch (Exception e) {}
+        finally {
+            serverCacheWriter.close();
+        }
+    }
+
+    /**
+     * Ensure that exceptions thrown by an underlying cache Writer are re-thrown.
+     */
+    @Test
+    public void shouldRethrowExceptions() {
+
+        FailingCacheWriter<String, String> failingCacheWriter = new FailingCacheWriter<>();
+
+        CacheWriterServer<String, String> serverCacheWriter = new CacheWriterServer<>(10000,
+                                                                  failingCacheWriter);
+
+        try {
+            serverCacheWriter.open();
+
+            CacheWriterClient<String, String> clientCacheWriter =
+                new CacheWriterClient<>(serverCacheWriter.getInetAddress(), 10000);
+
+            Cache.Entry<String, String> entry = new Entry<>("hello", "gudday");
+
+            clientCacheWriter.write(entry);
+
+            fail("An UnsupportedOperationException should have been thrown");
+        } catch (Exception e) {}
+        finally {
+            serverCacheWriter.close();
+        }
+    }
+
+    /**
+     * Ensure that <code>null</code> entries can be passed from the
+     * {@link CacheWriterServer} back to the {@link CacheWriterClient}.
+     */
+
+    /*
+     * @Test
+     * public void shouldLoadNullEntriesFromServerWithClient() {
+     *
+     *   NullEntryCacheWriter<String, String> nullCacheWriter = new NullEntryCacheWriter<>();
+     *
+     *   CacheWriterServer<String, String> serverCacheWriter =
+     *   new CacheWriterServer<String, String>(10000, nullCacheWriter);
+     *
+     *   try {
+     *       serverCacheWriter.open();
+     *
+     *       CacheWriterClient<String, String> clientCacheWriter =
+     *       new CacheWriterClient<>(serverCacheWriter.getInetAddress(), 10000);
+     *
+     *       Cache.Entry<String, String> entry = new Entry<String,String>("hello", "gudday");
+     *
+     *       Cache.Entry<String, String> entry = clientCacheWriter.write(entry);
+     *
+     *       Assert.assertThat(entry, is(nullValue()));
+     *   } catch (Exception e) {
+     *
+     *   } finally {
+     *       serverCacheWriter.close();
+     *   }
+     * }
+     */
+
+    private static class Entry<K, V> implements Cache.Entry<K, V> {
+        private K key;
+        private V value;
+
+        public Entry(K key, V value) {
+            setKey(key);
+            setValue(value);
+        }
+
+        @Override
+        public K getKey() {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        @Override
+        public V getValue() {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> clazz) {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        public void setKey(K key) {
+            this.key = key;
+        }
+
+        public void setValue(V value) {
+            this.value = value;
+        }
+    }
+}

--- a/cache-tests/src/test/java/org/jsr107/tck/integration/CacheWriterTest.java
+++ b/cache-tests/src/test/java/org/jsr107/tck/integration/CacheWriterTest.java
@@ -14,606 +14,1248 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
+
+
 package org.jsr107.tck.integration;
 
 import org.jsr107.tck.testutil.ExcludeListExcluder;
 import org.jsr107.tck.testutil.TestSupport;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import javax.cache.Cache;
-import javax.cache.configuration.FactoryBuilder;
-import javax.cache.configuration.MutableConfiguration;
-import javax.cache.integration.CacheWriter;
-import java.io.Serializable;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
+
+import java.util.*;
+
+import javax.cache.Cache;
+import javax.cache.CacheException;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import javax.cache.configuration.FactoryBuilder;
+import javax.cache.configuration.MutableConfiguration;
+import javax.cache.integration.CompletionListenerFuture;
+
 /**
- * Unit test for {@link javax.cache.integration.CacheWriter}s.
+ * Functional test for {@link javax.cache.integration.CacheWriter}s.
  *
- * @author Brian Oliver
+ * Cache methods are tested in order listed in Write-Through Caching table in JCache specification.
+ *
+ * @author Joe Fialli
  */
 public class CacheWriterTest extends TestSupport {
 
-  /**
-   * Rule used to exclude tests
-   */
-  @Rule
-  public ExcludeListExcluder rule = new ExcludeListExcluder(this.getClass());
-
-  /**
-   * The CacheWriter used for the tests.
-   */
-  private RecordingCacheWriter<Integer, String> cacheWriter;
-
-  /**
-   * The test Cache that will be configured to use the CacheWriter.
-   */
-  private Cache<Integer, String> cache;
-
-  @Before
-  public void setup() {
-    cacheWriter = new RecordingCacheWriter<Integer, String>();
-
-    MutableConfiguration<Integer, String> config = new MutableConfiguration<Integer, String>();
-    config.setCacheWriterFactory(FactoryBuilder.factoryOf(cacheWriter));
-    config.setWriteThrough(true);
-
-    getCacheManager().createCache(getTestCacheName(), config);
-    cache = getCacheManager().getCache(getTestCacheName());
-  }
-
-  @After
-  public void cleanup() {
-    for (String cacheName : getCacheManager().getCacheNames()) {
-      getCacheManager().destroyCache(cacheName);
-    }
-  }
-
-  @Test
-  public void put_SingleEntry() {
-    assertEquals(0, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-
-    cache.put(1, "Gudday World");
-
-    assertEquals(1, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-    assertTrue(cacheWriter.containsKey(1));
-    assertEquals("Gudday World", cacheWriter.get(1));
-  }
-
-  @Test
-  public void put_SingleEntryMultipleTimes() {
-    assertEquals(0, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-
-    cache.put(1, "Gudday World");
-    cache.put(1, "Bonjour World");
-    cache.put(1, "Hello World");
-
-    assertEquals(3, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-    assertTrue(cacheWriter.containsKey(1));
-    assertEquals("Hello World", cacheWriter.get(1));
-  }
-
-  @Test
-  public void put_DifferentEntries() {
-    assertEquals(0, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-
-    cache.put(1, "Gudday World");
-    cache.put(2, "Bonjour World");
-    cache.put(3, "Hello World");
-
-    assertEquals(3, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-
-    assertTrue(cacheWriter.containsKey(1));
-    assertEquals("Gudday World", cacheWriter.get(1));
-
-    assertTrue(cacheWriter.containsKey(2));
-    assertEquals("Bonjour World", cacheWriter.get(2));
-
-    assertTrue(cacheWriter.containsKey(3));
-    assertEquals("Hello World", cacheWriter.get(3));
-  }
-
-  @Test
-  public void getAndPut_SingleEntryMultipleTimes() {
-    assertEquals(0, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-
-    cache.getAndPut(1, "Gudday World");
-    cache.getAndPut(1, "Bonjour World");
-    cache.getAndPut(1, "Hello World");
-
-    assertEquals(3, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-    assertTrue(cacheWriter.containsKey(1));
-    assertEquals("Hello World", cacheWriter.get(1));
-  }
-
-  @Test
-  public void getAndPut_DifferentEntries() {
-    assertEquals(0, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-
-    cache.getAndPut(1, "Gudday World");
-    cache.getAndPut(2, "Bonjour World");
-    cache.getAndPut(3, "Hello World");
-
-    assertEquals(3, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-
-    assertTrue(cacheWriter.containsKey(1));
-    assertEquals("Gudday World", cacheWriter.get(1));
-
-    assertTrue(cacheWriter.containsKey(2));
-    assertEquals("Bonjour World", cacheWriter.get(2));
-
-    assertTrue(cacheWriter.containsKey(3));
-    assertEquals("Hello World", cacheWriter.get(3));
-  }
-
-  @Test
-  public void putIfAbsent_SingleEntryMultipleTimes() {
-    assertEquals(0, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-
-    cache.putIfAbsent(1, "Gudday World");
-    cache.putIfAbsent(1, "Bonjour World");
-    cache.putIfAbsent(1, "Hello World");
-
-    assertEquals(1, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-    assertTrue(cacheWriter.containsKey(1));
-    assertEquals("Gudday World", cacheWriter.get(1));
-  }
-
-  @Test
-  public void replaceMatching_SingleEntryMultipleTimes() {
-    assertEquals(0, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-
-    cache.putIfAbsent(1, "Gudday World");
-    cache.replace(1, "Gudday World", "Bonjour World");
-    cache.replace(1, "Gudday World", "Hello World");
-    cache.replace(1, "Bonjour World", "Hello World");
-
-    assertEquals(3, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-    assertTrue(cacheWriter.containsKey(1));
-    assertEquals("Hello World", cacheWriter.get(1));
-  }
-
-  @Test
-  public void replaceExisting_SingleEntryMultipleTimes() {
-    assertEquals(0, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-
-    cache.replace(1, "Gudday World");
-    cache.putIfAbsent(1, "Gudday World");
-    cache.replace(1, "Bonjour World");
-    cache.replace(1, "Hello World");
-
-    assertEquals(3, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-    assertTrue(cacheWriter.containsKey(1));
-    assertEquals("Hello World", cacheWriter.get(1));
-  }
-
-  @Test
-  public void getAndReplace_SingleEntryMultipleTimes() {
-    assertEquals(0, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-
-    cache.getAndReplace(1, "Gudday World");
-    cache.putIfAbsent(1, "Gudday World");
-    cache.getAndReplace(1, "Bonjour World");
-    cache.getAndReplace(1, "Hello World");
-
-    assertEquals(3, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-    assertTrue(cacheWriter.containsKey(1));
-    assertEquals("Hello World", cacheWriter.get(1));
-  }
-
-  @Test
-  public void invoke_CreateEntry() {
-    assertEquals(0, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-
-    cache.invoke(1, new Cache.EntryProcessor<Integer, String, Void>() {
-      @Override
-      public Void process(Cache.MutableEntry<Integer, String> entry, Object... arguments) {
-        entry.setValue("Gudday World");
-        return null;
-      }
-    });
-
-    assertEquals(1, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-    assertTrue(cacheWriter.containsKey(1));
-    assertEquals("Gudday World", cacheWriter.get(1));
-  }
-
-  @Test
-  public void invoke_UpdateEntry() {
-    assertEquals(0, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-
-    cache.put(1, "Gudday World");
-    cache.invoke(1, new Cache.EntryProcessor<Integer, String, Void>() {
-      @Override
-      public Void process(Cache.MutableEntry<Integer, String> entry, Object... arguments) {
-        entry.setValue("Hello World");
-        return null;
-      }
-    });
-
-    assertEquals(2, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-    assertTrue(cacheWriter.containsKey(1));
-    assertEquals("Hello World", cacheWriter.get(1));
-  }
-
-  @Test
-  public void invoke_RemoveEntry() {
-    assertEquals(0, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-
-    cache.put(1, "Gudday World");
-    cache.invoke(1, new Cache.EntryProcessor<Integer, String, Void>() {
-      @Override
-      public Void process(Cache.MutableEntry<Integer, String> entry, Object... arguments) {
-        entry.remove();
-        return null;
-      }
-    });
-
-    assertEquals(1, cacheWriter.getWriteCount());
-    assertEquals(1, cacheWriter.getDeleteCount());
-    assertFalse(cacheWriter.containsKey(1));
-  }
-
-  @Test
-  public void remove_SingleEntry() {
-    assertEquals(0, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-
-    cache.put(1, "Gudday World");
-    cache.remove(1);
-
-    assertEquals(1, cacheWriter.getWriteCount());
-    assertEquals(1, cacheWriter.getDeleteCount());
-    assertFalse(cacheWriter.containsKey(1));
-  }
-
-  @Test
-  public void remove_SingleEntryMultipleTimes() {
-    assertEquals(0, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-
-    cache.put(1, "Gudday World");
-    cache.remove(1);
-    cache.remove(1);
-    cache.remove(1);
-
-    assertEquals(1, cacheWriter.getWriteCount());
-    assertEquals(3, cacheWriter.getDeleteCount());
-    assertFalse(cacheWriter.containsKey(1));
-  }
-
-  @Test
-  public void remove_SpecificEntry() {
-    assertEquals(0, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-
-    cache.put(1, "Gudday World");
-    cache.remove(1, "Hello World");
-    cache.remove(1, "Gudday World");
-    cache.remove(1, "Gudday World");
-    cache.remove(1);
-
-    assertEquals(1, cacheWriter.getWriteCount());
-    assertEquals(2, cacheWriter.getDeleteCount());
-    assertFalse(cacheWriter.containsKey(1));
-  }
-
-  @Test
-  public void getAndRemove_SingleEntry() {
-    assertEquals(0, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-
-    cache.getAndRemove(1);
-    cache.put(1, "Gudday World");
-    cache.getAndRemove(1);
-
-    assertEquals(1, cacheWriter.getWriteCount());
-    assertEquals(2, cacheWriter.getDeleteCount());
-    assertFalse(cacheWriter.containsKey(1));
-  }
-
-  @Test
-  public void iterator_remove() {
-    assertEquals(0, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-
-    cache.getAndPut(1, "Gudday World");
-    cache.getAndPut(2, "Bonjour World");
-    cache.getAndPut(3, "Hello World");
-
-    Iterator<Cache.Entry<Integer, String>> iterator = cache.iterator();
-
-    iterator.next();
-    iterator.remove();
-    iterator.next();
-    iterator.next();
-    iterator.remove();
-
-    assertEquals(3, cacheWriter.getWriteCount());
-    assertEquals(2, cacheWriter.getDeleteCount());
-  }
-
-  @Test
-  public void putAll() {
-    assertEquals(0, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-
-    HashMap<Integer, String> map = new HashMap<Integer, String>();
-    map.put(1, "Gudday World");
-    map.put(2, "Bonjour World");
-    map.put(3, "Hello World");
-
-    cache.putAll(map);
-
-    assertEquals(3, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-
-    for (Integer key : map.keySet()) {
-      assertTrue(cacheWriter.containsKey(key));
-      assertEquals(map.get(key), cacheWriter.get(key));
-      assertTrue(cache.containsKey(key));
-      assertEquals(map.get(key), cache.get(key));
-    }
-
-    map.put(4, "Hola World");
-
-    cache.putAll(map);
-
-    assertEquals(7, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-
-    for (Integer key : map.keySet()) {
-      assertTrue(cacheWriter.containsKey(key));
-      assertEquals(map.get(key), cacheWriter.get(key));
-      assertTrue(cache.containsKey(key));
-      assertEquals(map.get(key), cache.get(key));
-    }
-  }
-
-  @Test
-  public void removeAll() {
-    assertEquals(0, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-
-    HashMap<Integer, String> map = new HashMap<Integer, String>();
-    map.put(1, "Gudday World");
-    map.put(2, "Bonjour World");
-    map.put(3, "Hello World");
-
-    cache.putAll(map);
-
-    assertEquals(3, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-
-    for (Integer key : map.keySet()) {
-      assertTrue(cacheWriter.containsKey(key));
-      assertEquals(map.get(key), cacheWriter.get(key));
-      assertTrue(cache.containsKey(key));
-      assertEquals(map.get(key), cache.get(key));
-    }
-
-    cache.removeAll();
-
-    assertEquals(3, cacheWriter.getWriteCount());
-    assertEquals(3, cacheWriter.getDeleteCount());
-
-    for (Integer key : map.keySet()) {
-      assertFalse(cacheWriter.containsKey(key));
-      assertFalse(cache.containsKey(key));
-    }
-
-    map.put(4, "Hola World");
-
-    cache.putAll(map);
-
-    assertEquals(7, cacheWriter.getWriteCount());
-    assertEquals(3, cacheWriter.getDeleteCount());
-
-    for (Integer key : map.keySet()) {
-      assertTrue(cacheWriter.containsKey(key));
-      assertEquals(map.get(key), cacheWriter.get(key));
-      assertTrue(cache.containsKey(key));
-      assertEquals(map.get(key), cache.get(key));
-    }
-  }
-
-  @Test
-  public void removeAllSpecific() {
-    assertEquals(0, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-
-    HashMap<Integer, String> map = new HashMap<Integer, String>();
-    map.put(1, "Gudday World");
-    map.put(2, "Bonjour World");
-    map.put(3, "Hello World");
-    map.put(4, "Hola World");
-
-    cache.putAll(map);
-
-    assertEquals(4, cacheWriter.getWriteCount());
-    assertEquals(0, cacheWriter.getDeleteCount());
-
-    for (Integer key : map.keySet()) {
-      assertTrue(cacheWriter.containsKey(key));
-      assertEquals(map.get(key), cacheWriter.get(key));
-      assertTrue(cache.containsKey(key));
-      assertEquals(map.get(key), cache.get(key));
-    }
-
-    HashSet<Integer> set = new HashSet<Integer>();
-    set.add(1);
-    set.add(4);
-
-    cache.removeAll(set);
-
-    assertEquals(4, cacheWriter.getWriteCount());
-    assertEquals(2, cacheWriter.getDeleteCount());
-
-    for (Integer key : set) {
-      assertFalse(cacheWriter.containsKey(key));
-      assertFalse(cache.containsKey(key));
-    }
-
-    cache.put(4, "Howdy World");
-
-    assertEquals(5, cacheWriter.getWriteCount());
-    assertEquals(2, cacheWriter.getDeleteCount());
-
-    set.clear();
-    set.add(2);
-
-    cache.removeAll(set);
-
-    assertTrue(cacheWriter.containsKey(3));
-    assertTrue(cache.containsKey(3));
-    assertTrue(cacheWriter.containsKey(4));
-    assertTrue(cache.containsKey(4));
-  }
-
-  /**
-   * A CacheWriter implementation that records the entries written to it so
-   * that they may be later asserted.
-   *
-   * @param <K> the type of the keys
-   * @param <V> the type of the values
-   */
-  public static class RecordingCacheWriter<K, V> implements CacheWriter<K, V>,
-      Serializable {
+    /**
+     * Rule used to exclude tests
+     */
+    @Rule
+    public ExcludeListExcluder rule = new ExcludeListExcluder(this.getClass());
 
     /**
-     * A map of keys to values that have been written.
+     * The test Cache that will be configured to use the CacheWriter.
      */
-    private ConcurrentHashMap<K, V> map;
+    private Cache<Integer, String> cache;
 
     /**
-     * The number of writes that have so far occurred.
+     * The {@link javax.cache.CacheManager} for the each test.
      */
-    private AtomicLong writeCount;
+    private CacheManager cacheManager;
+    private RecordingCacheWriter<Integer, String> cacheWriter;
 
     /**
-     * The number of deletes that have so far occurred.
+     * A {@link CacheWriterServer} that will delegate {@link Cache} request
+     * onto the recording {@link javax.cache.integration.CacheWriter}.
      */
-    private AtomicLong deleteCount;
+    private CacheWriterServer<Integer, String> cacheWriterServer;
 
     /**
-     * Constructs a RecordingCacheWriter.
+     * Configure write-through before each test.
      */
-    public RecordingCacheWriter() {
-      this.map = new ConcurrentHashMap<K, V>();
-      this.writeCount = new AtomicLong();
-      this.deleteCount = new AtomicLong();
+    @Before
+    public void onBeforeEachTest() throws IOException {
+
+        // establish and open a CacheLoaderServer to handle cache
+        // cache loading requests from a CacheLoaderClient
+        cacheWriter = new RecordingCacheWriter<>();
+        cacheWriterServer = new CacheWriterServer<>(10000, cacheWriter);
+        cacheWriterServer.open();
+
+        // establish the CacheManager for the tests
+        cacheManager = Caching.getCachingProvider().getCacheManager();
+
+        // establish a CacheWriterClient that a Cache can use for writing/deleting entries
+        // (via the CacheWriterServer)
+        CacheWriterClient<Integer, String> theCacheWriter = new CacheWriterClient<>(cacheWriterServer.getInetAddress(),
+                                                                cacheWriterServer.getPort());
+
+        MutableConfiguration<Integer, String> configuration = new MutableConfiguration<>();
+        configuration.setTypes(Integer.class, String.class);
+        configuration.setCacheWriterFactory(FactoryBuilder.factoryOf(theCacheWriter));
+        configuration.setWriteThrough(true);
+
+        getCacheManager().createCache("cache-writer-test", configuration);
+        cache = getCacheManager().getCache("cache-writer-test", Integer.class, String.class);
     }
 
-    @Override
-    public void write(Cache.Entry<? extends K, ? extends V> entry) {
-      V previous = map.put(entry.getKey(), entry.getValue());
-      writeCount.incrementAndGet();
+    @After
+    public void cleanup() {
+
+        // destroy the cache
+        String cacheName = cache.getName();
+        cacheManager.destroyCache(cacheName);
+
+        // close the CacheWriterServer
+        cacheWriterServer.close();
+        cacheWriterServer = null;
+
+        cache = null;
     }
 
-    @Override
-    public void writeAll(Collection<Cache.Entry<? extends K, ? extends V>> entries) {
-      Iterator<Cache.Entry<? extends K, ? extends V>> iterator = entries.iterator();
+    @Test
+    public void shouldNotWriteThroughCallingContainsKeyOnExistingKey() {
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
 
-      while (iterator.hasNext()) {
-        write(iterator.next());
+        // containsKey returns true case.
+        cache.put(1, "Gudday World");
+        assertEquals(1, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        cache.containsKey(1);
+        assertEquals(1, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+    }
+
+    @Test
+    public void shouldNotInvokeWriteThroughCallingContainsKeyOnMissingKey() {
+
+        // containsKey returns false case.
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+        cache.containsKey(1);
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+    }
+
+    @Test
+    public void shouldNotInvokeWriteThroughCallingGetOnMissingEntry() {
+
+        // get returns null case.
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+        cache.get(1);
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+    }
+
+    @Test
+    public void shouldNotInvokeWriteThroughCallingGetOnExistingEntry() {
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        // get returns non-null case.
+        cache.put(1, "Gudday World");
+        assertEquals(1, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        String value = cache.get(1);
+        assertEquals("Gudday World", value);
+        assertEquals(1, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+    }
+
+    @Test
+    public void shouldNotInvokeWriteThroughCallingGetAll() {
+        int NUM_KEYS = 4;
+        Set<Integer> keys = new HashSet<>();
+        for (int i = 1; i <= NUM_KEYS; i++) {
+            keys.add(i);
+        }
+
+        // getAll returns null case.
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+        Map<Integer, String> map = cache.getAll(keys);
+        assertTrue(map.size() == 0);
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        // getAll returns non-null case.
+        for (Integer key : keys) {
+            cache.put(key, "value" + key);
+        }
+
+        assertEquals(NUM_KEYS, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        map = cache.getAll(keys);
+        assertEquals(keys.size(), map.size());
+        assertEquals(NUM_KEYS, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+    }
+
+    @Test
+    public void shouldWriteThroughUsingGetAndPut_SingleEntryMultipleTimes() {
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+        cache.getAndPut(1, "Gudday World");
+        cache.getAndPut(1, "Gudday World");
+        cache.getAndPut(1, "Gudday World");
+
+        assertEquals(3, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+        assertTrue(cacheWriter.hasWritten(1));
+        assertEquals("Gudday World", cacheWriter.get(1));
+    }
+
+    @Test
+    public void shouldWriteThroughUsingGetAndPut_DifferentEntries() {
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+        cache.getAndPut(1, "Gudday World");
+        cache.getAndPut(2, "Bonjour World");
+        cache.getAndPut(3, "Hello World");
+
+        assertEquals(3, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        assertTrue(cacheWriter.hasWritten(1));
+        assertEquals("Gudday World", cacheWriter.get(1));
+
+        assertTrue(cacheWriter.hasWritten(2));
+        assertEquals("Bonjour World", cacheWriter.get(2));
+
+        assertTrue(cacheWriter.hasWritten(3));
+        assertEquals("Hello World", cacheWriter.get(3));
+    }
+
+    @Test
+    public void shouldWriteThroughUsingGetAndRemove_MissingSingleEntry() {
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        // remove a missing entry case
+        String value = cache.getAndRemove(1);
+        assertEquals(value, null);
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(1, cacheWriter.getDeleteCount());
+    }
+
+    @Test
+    public void shouldWriteThroughUsingGetAndRemove_ExistingSingleEntry() {
+        int nDelete = 0;
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        // actual remove of an entry case
+        cache.put(1, "Gudday World");
+        String value = cache.getAndRemove(1);
+        assertEquals("Gudday World", value);
+        nDelete++;
+
+        assertEquals(1, cacheWriter.getWriteCount());
+        assertEquals(nDelete, cacheWriter.getDeleteCount());
+        assertFalse(cacheWriter.hasWritten(1));
+    }
+
+    @Test
+    public void shouldNotWriteThroughUsingGetAndReplace_MissingSingleEntry() {
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        // replace does not occur since key 1 does not exist in cache
+        String value = cache.getAndReplace(1, "Gudday World");
+        assertEquals(value, null);
+        assertEquals(cache.containsKey(1), false);
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+    }
+
+    @Test
+    public void shouldWriteThroughUsingGetAndReplace_ExistingSingleEntry() {
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        // actual replace of an entry case
+        cache.put(1, "Gudday World");
+        String value = cache.getAndReplace(1, "Hello World");
+        assertEquals(value, "Gudday World");
+        assertEquals(2, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+        assertEquals(cache.get(1), cacheWriter.get(1));
+        assertTrue(cacheWriter.hasWritten(1));
+    }
+
+    @Test
+    public void shouldWriteThroughUsingGetAndReplace_SingleEntryMultipleTimes() {
+        int nWrite = 0;
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        String previousValue = cache.getAndReplace(1, "Gudday World");
+        assertEquals(previousValue, null);
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        boolean result = cache.putIfAbsent(1, "Gudday World");
+        assertTrue(result);
+        nWrite++;
+        assertEquals(nWrite, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        previousValue = cache.getAndReplace(1, "Bonjour World");
+        assertEquals(previousValue, "Gudday World");
+        nWrite++;
+        assertEquals(cache.get(1), cacheWriter.get(1));
+        assertEquals("Bonjour World", cacheWriter.get(1));
+        assertEquals("Bonjour World", cache.get(1));
+        assertEquals(nWrite, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        previousValue = cache.getAndReplace(1, "Hello World");
+        assertEquals("Bonjour World", previousValue);
+        nWrite++;
+        assertEquals(cache.get(1), cacheWriter.get(1));
+        assertEquals(previousValue, "Bonjour World");
+        assertEquals(nWrite, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+        assertTrue(cacheWriter.hasWritten(1));
+        assertEquals("Hello World", cacheWriter.get(1));
+    }
+
+    @Test
+    public void shouldWriteThroughUsingInvoke_setValue_CreateEntry() {
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        cache.invoke(1, new Cache.EntryProcessor<Integer, String, Void>() {
+            @Override
+            public Void process(Cache.MutableEntry<Integer, String> entry, Object... arguments) {
+                entry.setValue("Gudday World");
+
+                return null;
+            }
+        });
+
+        assertEquals(1, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+        assertTrue(cacheWriter.hasWritten(1));
+        assertEquals("Gudday World", cacheWriter.get(1));
+    }
+
+    @Test
+    public void shouldWriteThroughUsingInvokeAll_setValue_CreateEntry() {
+        final String VALUE_PREFIX = "value_";
+        final int NUM_KEYS = 10;
+
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        Set<Integer> keys = new HashSet<>();
+        for (int key = 1; key <= NUM_KEYS; key++) {
+            keys.add(key);
+        }
+
+        cache.invokeAll(keys, new Cache.EntryProcessor<Integer, String, Void>() {
+            @Override
+            public Void process(Cache.MutableEntry<Integer, String> entry, Object... arguments) {
+                entry.setValue(VALUE_PREFIX + entry.getKey());
+
+                return null;
+            }
+        });
+
+        assertEquals(NUM_KEYS, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+        for (Integer key : keys) {
+            String computedValue = VALUE_PREFIX + key;
+            assertTrue(cacheWriter.hasWritten(key));
+            assertEquals(computedValue, cacheWriter.get(key));
+            assertEquals(computedValue, cache.get(key));
+        }
+    }
+
+    @Test
+    public void shouldWriteThroughUsingInvoke_setValue_UpdateEntry() {
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        cache.put(1, "Gudday World");
+        cache.invoke(1, new Cache.EntryProcessor<Integer, String, Void>() {
+            @Override
+            public Void process(Cache.MutableEntry<Integer, String> entry, Object... arguments) {
+                entry.setValue("Hello World");
+
+                return null;
+            }
+        });
+
+        assertEquals(2, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+        assertTrue(cacheWriter.hasWritten(1));
+        assertEquals("Hello World", cacheWriter.get(1));
+    }
+
+    @Test
+    public void shouldWriteThroughUsingInvokeAll_setValue_UpdateEntry() {
+        final String VALUE_PREFIX_ORIGINAL = "value_";
+        final String VALUE_PREFIX_UPDATED = "updateValue_";
+        final int NUMBER_OF_KEYS = 10;
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        Set<Integer> keys = new HashSet<>();
+        for (int key = 1; key <= NUMBER_OF_KEYS; key++) {
+            keys.add(key);
+            cache.put(key, VALUE_PREFIX_ORIGINAL + key);
+        }
+
+        assertEquals(NUMBER_OF_KEYS, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+        cache.invokeAll(keys, new Cache.EntryProcessor<Integer, String, Void>() {
+            @Override
+            public Void process(Cache.MutableEntry<Integer, String> entry, Object... arguments) {
+                entry.setValue(VALUE_PREFIX_UPDATED + entry.getKey());
+
+                return null;
+            }
+        });
+
+        assertEquals(NUMBER_OF_KEYS * 2, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+        for (Integer key : keys) {
+            String computedValue = VALUE_PREFIX_UPDATED + key;
+            assertTrue(cacheWriter.hasWritten(key));
+            assertEquals(computedValue, cacheWriter.get(key));
+            assertEquals(computedValue, cache.get(key));
+        }
+    }
+
+    @Test
+    public void shouldWriteThroughUsingInvoke_remove() {
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        cache.put(1, "Gudday World");
+        cache.invoke(1, new Cache.EntryProcessor<Integer, String, Void>() {
+            @Override
+            public Void process(Cache.MutableEntry<Integer, String> entry, Object... arguments) {
+                entry.remove();
+
+                return null;
+            }
+        });
+
+        assertEquals(1, cacheWriter.getWriteCount());
+        assertEquals(1, cacheWriter.getDeleteCount());
+        assertFalse(cacheWriter.hasWritten(1));
+    }
+
+    @Test
+    public void shouldWriteThroughUsingInvokeAll_setValue_RemoveEntry() {
+        final String VALUE_PREFIX = "value_";
+        final int NUM_KEYS = 10;
+
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        Set<Integer> keys = new HashSet<>();
+        for (int key = 1; key <= NUM_KEYS; key++) {
+            keys.add(key);
+            cache.put(key, VALUE_PREFIX + key);
+        }
+
+        assertEquals(NUM_KEYS, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        cache.invokeAll(keys, new Cache.EntryProcessor<Integer, String, Void>() {
+            @Override
+            public Void process(Cache.MutableEntry<Integer, String> entry, Object... arguments) {
+                entry.remove();
+
+                return null;
+            }
+        });
+        assertEquals(NUM_KEYS, cacheWriter.getWriteCount());
+        assertEquals(NUM_KEYS, cacheWriter.getDeleteCount());
+
+        for (Integer key : keys) {
+            assertFalse(cacheWriter.hasWritten(key));
+            assertEquals(null, cacheWriter.get(key));
+            assertEquals(null, cache.get(key));
+        }
+    }
+
+    @Test
+    public void shouldWriteThroughUsingInvoke_remove_nonExistingEntry() {
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        cache.invoke(1, new Cache.EntryProcessor<Integer, String, Void>() {
+            @Override
+            public Void process(Cache.MutableEntry<Integer, String> entry, Object... arguments) {
+                entry.remove();
+
+                return null;
+            }
+        });
+
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(1, cacheWriter.getDeleteCount());
+        assertFalse(cacheWriter.hasWritten(1));
+    }
+
+    @Test
+    public void shouldWriteThroughUsingInvoke_remove_createEntry() {
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        cache.put(1, "Gudday World");
+        cache.invoke(1, new Cache.EntryProcessor<Integer, String, Void>() {
+            @Override
+            public Void process(Cache.MutableEntry<Integer, String> entry, Object... arguments) {
+                entry.remove();
+                entry.setValue("After remove");
+
+                return null;
+            }
+        });
+
+        assertEquals(2, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+        assertTrue(cacheWriter.hasWritten(1));
+    }
+
+    @Test
+    public void shouldWriteThroughUsingInvoke_setValue_CreateEntryThenRemove() {
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        cache.invoke(1, new Cache.EntryProcessor<Integer, String, Void>() {
+            @Override
+            public Void process(Cache.MutableEntry<Integer, String> entry, Object... arguments) {
+                entry.setValue("Gudday World");
+                entry.remove();
+
+                return null;
+            }
+        });
+
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+        assertTrue(!cacheWriter.hasWritten(1));
+        assertTrue(cache.get(1) == null);
+        assertFalse(cache.containsKey(1));
+    }
+
+    @Test
+    public void shouldWriteThroughUsingInvoke_setValue_CreateEntryGetValue() {
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        String value = cache.invoke(1, new Cache.EntryProcessor<Integer, String, String>() {
+            @Override
+            public String process(Cache.MutableEntry<Integer, String> entry, Object... arguments) {
+                entry.setValue("Gudday World");
+
+                return entry.getValue();
+            }
+        });
+
+        assertEquals(value, "Gudday World");
+        assertEquals(value, cache.get(1));
+        assertEquals(cache.get(1), cacheWriter.get(1));
+        assertEquals(1, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+        assertTrue(cacheWriter.hasWritten(1));
+        assertEquals("Gudday World", cacheWriter.get(1));
+    }
+
+    @Test
+    public void shouldNotWriteThroughUsingIterator() {
+        final String VALUE_PREFIX = "value_";
+        final int NUMBER_OF_KEYS = 10;
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        Set<Integer> keys = new HashSet<>();
+        for (int aKey = 1; aKey <= NUMBER_OF_KEYS; aKey++) {
+            keys.add(aKey);
+            cache.put(aKey, VALUE_PREFIX + aKey);
+        }
+
+        assertEquals(NUMBER_OF_KEYS, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        int i = 0;
+        for (Cache.Entry<Integer, String> entry : cache) {
+            i++;
+            assertEquals(entry.getValue(), cacheWriter.get(entry.getKey()));
+        }
+        assertEquals(NUMBER_OF_KEYS, i);
+
+        assertEquals(NUMBER_OF_KEYS, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+    }
+
+    @Test
+    public void shouldNotWriteThroughUsingLoadAll() throws Exception {
+        final int NUMBER_OF_KEYS = 10;
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        Set<Integer> keys = new HashSet<>();
+        for (int key = 1; key <= NUMBER_OF_KEYS; key++) {
+            keys.add(key);
+        }
+
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+        CompletionListenerFuture future = new CompletionListenerFuture();
+
+        cache.loadAll(keys, true, future);
+
+        // wait for the load to complete
+        future.get();
+
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+    }
+
+    /**
+     * Test constraint that cache is not mutated when CacheException is thrown by
+     * {@link javax.cache.integration.CacheWriter#write(javax.cache.Cache.Entry)}
+     */
+    @Test
+    public void shouldNotPutWhenWriteThroughFails() {
+        cacheWriterServer.setCacheWriter(new FailingCacheWriter<Integer, String>());
+
+        try {
+            cache.put(1, "Gudday World");
+            assertTrue("expected exception on write-through", false);
+        } catch (CacheException e) {
+
+            // ignore expected exception.
+
+        } catch (RuntimeException re) {
+
+            // possible path. reconcile with outcome of jsr 107 spec jira 222
+            //assertTrue("expected CacheException, handled " + re.getClass().getCanonicalName(), false);
+        }
+
+        assertFalse(cache.containsKey(1));
+    }
+
+    @Test
+    public void shouldWriteThoughUsingPutSingleEntry() {
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        cache.put(1, "Gudday World");
+
+        assertEquals(1, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+        assertTrue(cacheWriter.hasWritten(1));
+        assertEquals("Gudday World", cacheWriter.get(1));
+    }
+
+    @Test
+    public void shouldWriteThroughUsingPutSingleEntryMultipleTimes() {
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        cache.put(1, "Gudday World");
+        cache.put(1, "Bonjour World");
+        cache.put(1, "Hello World");
+
+        assertEquals(3, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+        assertTrue(cacheWriter.hasWritten(1));
+        assertEquals("Hello World", cacheWriter.get(1));
+    }
+
+    @Test
+    public void shouldWriteThroughUsingPutOfDifferentEntries() {
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        cache.put(1, "Gudday World");
+        cache.put(2, "Bonjour World");
+        cache.put(3, "Hello World");
+
+        assertEquals(3, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        assertTrue(cacheWriter.hasWritten(1));
+        assertEquals("Gudday World", cacheWriter.get(1));
+
+        assertTrue(cacheWriter.hasWritten(2));
+        assertEquals("Bonjour World", cacheWriter.get(2));
+
+        assertTrue(cacheWriter.hasWritten(3));
+        assertEquals("Hello World", cacheWriter.get(3));
+    }
+
+    @Test
+    public void shouldWriteThoughUsingPutAll() {
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        HashMap<Integer, String> map = new HashMap<>();
+        map.put(1, "Gudday World");
+        map.put(2, "Bonjour World");
+        map.put(3, "Hello World");
+
+        cache.putAll(map);
+
+        assertEquals(3, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        for (Integer key : map.keySet()) {
+            assertTrue(cacheWriter.hasWritten(key));
+            assertTrue(cache.containsKey(key));
+            assertEquals(cache.get(key), cacheWriter.get(key));
+            assertEquals(map.get(key), cache.get(key));
+        }
+
+        map.put(4, "Hola World");
+
+        cache.putAll(map);
+
+        assertEquals(7, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        for (Integer key : map.keySet()) {
+            assertTrue(cacheWriter.hasWritten(key));
+            assertEquals(map.get(key), cacheWriter.get(key));
+            assertTrue(cache.containsKey(key));
+            assertEquals(map.get(key), cache.get(key));
+        }
+    }
+
+    @Test
+    public void shouldWriteThoughUsingPutAll_partialSuccess() {
+        cacheWriter = new BatchPartialSuccessRecordingClassWriter<>(3, 100);
+        cacheWriterServer.setCacheWriter(cacheWriter);
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        HashMap<Integer, String> map = new HashMap<>();
+        map.put(1, "Gudday World");
+        map.put(2, "Bonjour World");
+        map.put(3, "Hello World");
+        map.put(4, "Ciao World");
+
+        try {
+            cache.putAll(map);
+            assertTrue("expected CacheException to be thrown for BatchPartialSuccessRecordingClassWriter", false);
+        } catch (CacheException ce) {
+
+            // ignore expected exception
+
+        } catch (RuntimeException re) {
+
+            // possible path. reconcile with outcome of jsr 107 spec jira 222
+            // assertTrue("expected CacheException, handled " + re.getClass().getCanonicalName(), false);
+        }
+
+        int numSuccess = 0;
+        int numFailure = 0;
+        for (Integer key : map.keySet()) {
+            if (cacheWriter.hasWritten(key)) {
+                assertTrue(cache.containsKey(key));
+                assertEquals(map.get(key), cacheWriter.get(key));
+                assertEquals(map.get(key), cache.get(key));
+                numSuccess++;
+            } else {
+                assertFalse(cache.containsKey(key));
+                assertFalse(cacheWriter.hasWritten(key));
+                assertEquals(cache.get(key), cacheWriter.get(key));
+                numFailure++;
+            }
+
+            assertEquals(cache.get(key), cacheWriter.get(key));
+        }
+
+        assertEquals(numSuccess + numFailure, map.size());
+        assertEquals(numSuccess, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+    }
+
+    @Test
+    public void shouldWriteThoughUsingPutIfAbsent_SingleEntryMultipleTimes() {
+        int nWrite = 0;
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        boolean result = cache.putIfAbsent(1, "Gudday World");
+        assertTrue(result);
+        nWrite++;
+
+        result = cache.putIfAbsent(1, "Bonjour World");
+        assertFalse(result);
+
+        result = cache.putIfAbsent(1, "Hello World");
+        assertFalse(result);
+
+        assertEquals(nWrite, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+        assertTrue(cacheWriter.hasWritten(1));
+        assertEquals("Gudday World", cacheWriter.get(1));
+    }
+
+    @Test
+    public void shouldWriteThroughRemoveNonexistentKey() {
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        boolean result = cache.remove(1);
+        assertFalse(result);
+        assertEquals(1, cacheWriter.getDeleteCount());
+    }
+
+    @Test
+    public void shouldWriteThroughRemove_SingleEntry() {
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        cache.put(1, "Gudday World");
+        assertEquals(1, cacheWriter.getWriteCount());
+
+        boolean result = cache.remove(1);
+        assertTrue(result);
+
+        assertEquals(1, cacheWriter.getDeleteCount());
+        assertFalse(cacheWriter.hasWritten(1));
+    }
+
+    /**
+     * Test constraint that cache is not mutated when CacheException is thrown by
+     * {@link javax.cache.integration.CacheWriter#delete(Object)}
+     */
+    @Test
+    public void shouldNotRemoveWhenWriteThroughFails() {
+        cache.put(1, "Gudday World");
+        assertTrue(cache.containsKey(1));
+
+        cacheWriterServer.setCacheWriter(new FailingCacheWriter<Integer, String>());
+
+        try {
+            cache.remove(1);
+            assertTrue("expected exception on write-through", false);
+        } catch (CacheException e) {
+
+            // ignore expected exception.
+
+        } catch (RuntimeException re) {
+
+            // possible path. reconcile with outcome of jsr 107 spec jira 222
+            //assertTrue("expected CacheException, handled " + re.getClass().getCanonicalName(), false);
+        }
+
+        assertTrue(cache.containsKey(1));
+    }
+
+    @Test
+    public void shouldWriteThroughRemove_SingleEntryMultipleTimes() {
+        int nDelete = 0;
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        cache.put(1, "Gudday World");
+        boolean result = cache.remove(1);
+        assertTrue(result);
+        nDelete++;
+
+        result = cache.remove(1);
+        assertFalse(result);
+        nDelete++;
+
+        result = cache.remove(1);
+        assertFalse(result);
+        nDelete++;
+
+        assertEquals(1, cacheWriter.getWriteCount());
+        assertEquals(nDelete, cacheWriter.getDeleteCount());
+    }
+
+    @Test
+    public void shouldWriteThroughRemove_SpecificEntry() {
+        int nDelete = 0;
+
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(nDelete, cacheWriter.getDeleteCount());
+
+        cache.put(1, "Gudday World");
+        boolean result = cache.remove(1, "Hello World");
+        assertFalse(result);
+        assertEquals(nDelete, cacheWriter.getDeleteCount());
+
+        result = cache.remove(1, "Gudday World");
+        assertTrue(result);
+        nDelete++;
+        assertEquals(nDelete, cacheWriter.getDeleteCount());
+
+        result = cache.remove(1, "Gudday World");
+        assertFalse(result);
+        assertEquals(nDelete, cacheWriter.getDeleteCount());
+
+        assertEquals(1, cacheWriter.getWriteCount());
+    }
+
+    @Test
+    public void shouldWriteThroughCacheIteratorRemove() {
+        int nDelete = 0;
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        cache.getAndPut(1, "Gudday World");
+        cache.getAndPut(2, "Bonjour World");
+        cache.getAndPut(3, "Hello World");
+
+        Iterator<Cache.Entry<Integer, String>> iterator = cache.iterator();
+        iterator.next();
         iterator.remove();
-      }
+        nDelete++;
+
+        iterator.next();
+        iterator.next();
+        iterator.remove();
+        nDelete++;
+
+        assertEquals(3, cacheWriter.getWriteCount());
+        assertEquals(nDelete, cacheWriter.getDeleteCount());
     }
 
-    @Override
-    public void delete(Object key) {
-      map.remove(key);
-      deleteCount.incrementAndGet();
+    @Test
+    public void shouldWriteThroughRemoveAll() {
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        HashMap<Integer, String> map = new HashMap<>();
+        map.put(1, "Gudday World");
+        map.put(2, "Bonjour World");
+        map.put(3, "Hello World");
+
+        cache.putAll(map);
+
+        assertEquals(3, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        for (Integer key : map.keySet()) {
+            assertTrue(cacheWriter.hasWritten(key));
+            assertEquals(map.get(key), cacheWriter.get(key));
+            assertTrue(cache.containsKey(key));
+            assertEquals(map.get(key), cache.get(key));
+        }
+
+        cache.removeAll();
+
+        assertEquals(3, cacheWriter.getWriteCount());
+        assertEquals(3, cacheWriter.getDeleteCount());
+
+        for (Integer key : map.keySet()) {
+            assertFalse(cacheWriter.hasWritten(key));
+            assertFalse(cache.containsKey(key));
+        }
+
+        map.put(4, "Hola World");
+
+        cache.putAll(map);
+
+        assertEquals(7, cacheWriter.getWriteCount());
+        assertEquals(3, cacheWriter.getDeleteCount());
+
+        for (Integer key : map.keySet()) {
+            assertTrue(cacheWriter.hasWritten(key));
+            assertEquals(map.get(key), cacheWriter.get(key));
+            assertTrue(cache.containsKey(key));
+            assertEquals(map.get(key), cache.get(key));
+        }
     }
 
-    @Override
-    public void deleteAll(Collection<?> entries) {
-      for (Iterator<?> keys = entries.iterator(); keys.hasNext(); ) {
-        delete(keys.next());
-        keys.remove();
-      }
+    @Test
+    public void shouldWriteThroughRemoveAll_partialSuccess() {
+        cacheWriter = new BatchPartialSuccessRecordingClassWriter<>(100, 3);
+        cacheWriterServer.setCacheWriter(cacheWriter);
+
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        HashMap<Integer, String> map = new HashMap<>();
+        map.put(1, "Gudday World");
+        map.put(2, "Bonjour World");
+        map.put(3, "Hello World");
+
+        cache.putAll(map);
+
+        assertEquals(3, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        for (Integer key : map.keySet()) {
+            assertTrue(cacheWriter.hasWritten(key));
+            assertEquals(map.get(key), cacheWriter.get(key));
+            assertTrue(cache.containsKey(key));
+            assertEquals(map.get(key), cache.get(key));
+        }
+
+        try {
+            cache.removeAll();
+            assertTrue("expected CacheException to be thrown for BatchPartialSuccessRecordingClassWriter", false);
+        } catch (CacheException ce) {
+
+            // ignore expected exception
+
+        } catch (RuntimeException re) {
+
+            // possible path. reconcile with outcome of jsr 107 spec jira 222
+            // assertTrue("expected CacheException, handled " + re.getClass().getCanonicalName(), false);
+        }
+
+        int numSuccess = 0;
+        int numFailure = 0;
+        for (Integer key : map.keySet()) {
+            if (cacheWriter.hasWritten(key)) {
+                assertTrue(cache.containsKey(key));
+                assertEquals(map.get(key), cacheWriter.get(key));
+                assertEquals(map.get(key), cache.get(key));
+                numFailure++;
+            } else {
+                assertFalse(cache.containsKey(key));
+                numSuccess++;
+            }
+
+            assertEquals(cache.get(key), cacheWriter.get(key));
+        }
+
+        assertEquals(numSuccess + numFailure, map.size());
+        assertEquals(3, cacheWriter.getWriteCount());
+        assertEquals(numSuccess, cacheWriter.getDeleteCount());
+    }
+
+    @Test
+    public void shouldUseWriteThroughRemoveAllSpecific() {
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        HashMap<Integer, String> map = new HashMap<>();
+        map.put(1, "Gudday World");
+        map.put(2, "Bonjour World");
+        map.put(3, "Hello World");
+        map.put(4, "Hola World");
+
+        cache.putAll(map);
+
+        assertEquals(4, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        for (Integer key : map.keySet()) {
+            assertTrue(cacheWriter.hasWritten(key));
+            assertEquals(map.get(key), cacheWriter.get(key));
+            assertTrue(cache.containsKey(key));
+            assertEquals(map.get(key), cache.get(key));
+        }
+
+        HashSet<Integer> set = new HashSet<>();
+        set.add(1);
+        set.add(4);
+
+        cache.removeAll(set);
+
+        assertEquals(4, cacheWriter.getWriteCount());
+        assertEquals(2, cacheWriter.getDeleteCount());
+
+        for (Integer key : set) {
+            assertFalse(cacheWriter.hasWritten(key));
+            assertFalse(cache.containsKey(key));
+        }
+
+        cache.put(4, "Howdy World");
+
+        assertEquals(5, cacheWriter.getWriteCount());
+        assertEquals(2, cacheWriter.getDeleteCount());
+
+        set.clear();
+        set.add(2);
+
+        cache.removeAll(set);
+        assertEquals(3, cacheWriter.getDeleteCount());
+
+        assertTrue(cacheWriter.hasWritten(3));
+        assertTrue(cache.containsKey(3));
+        assertTrue(cacheWriter.hasWritten(4));
+        assertTrue(cache.containsKey(4));
+    }
+
+    @Test
+    public void shouldWriteThroughRemoveAllSpecific_partialSuccess() {
+        cacheWriter = new BatchPartialSuccessRecordingClassWriter<>(100, 3);
+        cacheWriterServer.setCacheWriter(cacheWriter);
+
+        assertEquals(0, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        HashMap<Integer, String> map = new HashMap<>();
+        map.put(1, "Gudday World");
+        map.put(2, "Bonjour World");
+        map.put(3, "Hello World");
+        map.put(4, "Hola World");
+        map.put(5, "Ciao World");
+
+        cache.putAll(map);
+
+        assertEquals(5, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        for (Integer key : map.keySet()) {
+            assertTrue(cacheWriter.hasWritten(key));
+            assertEquals(map.get(key), cacheWriter.get(key));
+            assertTrue(cache.containsKey(key));
+            assertEquals(map.get(key), cache.get(key));
+        }
+
+        HashSet<Integer> set = new HashSet<>();
+        set.add(1);
+        set.add(4);
+        set.add(3);
+        set.add(2);
+
+        try {
+            cache.removeAll(set);
+            assertTrue("expected CacheException to be thrown for BatchPartialSuccessRecordingClassWriter", false);
+        } catch (CacheException ce) {
+
+            // ignore expected exception
+
+        } catch (RuntimeException re) {
+
+            // possible path. reconcile with outcome of jsr 107 spec jira 222
+            // assertTrue("expected CacheException, handled " + re.getClass().getCanonicalName(), false);
+        }
+
+        int numSuccess = 0;
+        int numFailure = 0;
+        for (Integer key : map.keySet()) {
+            if (cacheWriter.hasWritten(key)) {
+                assertTrue(cache.containsKey(key));
+                assertEquals(map.get(key), cacheWriter.get(key));
+                assertEquals(map.get(key), cache.get(key));
+                numFailure++;
+            } else {
+                assertFalse(cache.containsKey(key));
+                numSuccess++;
+            }
+
+            assertEquals(cache.get(key), cacheWriter.get(key));
+        }
+
+        assertEquals(numSuccess + numFailure, map.size());
+        assertEquals(5, cacheWriter.getWriteCount());
+        assertEquals(numSuccess, cacheWriter.getDeleteCount());
     }
 
     /**
-     * Gets the last written value of the specified key
-     *
-     * @param key the key
-     * @return the value last written
+     * Write-through Test for  method
+     * boolean replace(K key, V value)
      */
-    public V get(K key) {
-      return map.get(key);
+    @Test
+    public void shouldNotWriteThroughReplaceNonExistentKey() {
+        int nWrites = 0;
+        assertEquals(nWrites, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        boolean result = cache.replace(1, "Gudday World");
+        assertFalse(result);
+
+        assertEquals(nWrites, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
     }
 
     /**
-     * Determines if there is a last written value for the specified key
-     *
-     * @param key the key
-     * @return true if there is a last written value
+     * Write-through Test for  method
+     * boolean replace(K key, V value)
      */
-    public boolean containsKey(K key) {
-      return map.containsKey(key);
+    @Test
+    public void shouldWriteThroughReplaceExisting_SingleEntryMultipleTimes() {
+        int nWrites = 0;
+        assertEquals(nWrites, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        boolean result = cache.replace(1, "Gudday World");
+        assertFalse(result);
+
+        result = cache.putIfAbsent(1, "Gudday World");
+        assertTrue(result);
+        nWrites++;
+
+        result = cache.replace(1, "Bonjour World");
+        assertTrue(result);
+        nWrites++;
+
+        result = cache.replace(1, "Hello World");
+        assertTrue(result);
+        nWrites++;
+
+        assertEquals(nWrites, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+        assertTrue(cacheWriter.hasWritten(1));
+        assertEquals("Hello World", cacheWriter.get(1));
+        assertEquals(cache.get(1), cacheWriter.get(1));
     }
 
     /**
-     * Gets the number of writes that have occurred.
-     *
-     * @return the number of writes
+     * Write-through Test for  method
+     * boolean replace(K key, V oldValue, V newValue)
      */
-    public long getWriteCount() {
-      return writeCount.get();
+    @Test
+    public void shouldNotUseWriteThroughReplaceDoesNotMatch() {
+        int nWriter = 0;
+        assertEquals(nWriter, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+
+        boolean result = cache.putIfAbsent(1, "Gudday World");
+        assertTrue(result);
+        nWriter++;
+        assertEquals(1, cacheWriter.getWriteCount());
+
+        result = cache.replace(1, "Bonjour World", "Hello World");
+        assertFalse(result);
+        assertFalse("Hello World".equals(cache.get(1)));
+        assertEquals(nWriter, cacheWriter.getWriteCount());
+        assertEquals(0, cacheWriter.getDeleteCount());
+        assertTrue(cacheWriter.hasWritten(1));
+        assertEquals(cache.get(1), cacheWriter.get(1));
     }
 
-    /**
-     * Gets the number of deletes that have occurred.
-     *
-     * @return the number of writes
-     */
-    public long getDeleteCount() {
-      return deleteCount.get();
-    }
+    static public class Entry<K, V> implements Cache.Entry<K, V> {
+        private K key;
+        private V value;
 
-    /**
-     * Clears the contents of stored values.
-     */
-    public void clear() {
-      map.clear();
-      this.writeCount = new AtomicLong();
-      this.deleteCount = new AtomicLong();
+        public Entry(K k, V v) {
+            this.key = k;
+            this.value = v;
+        }
+
+        @Override
+        public K getKey() {
+            return key;
+        }
+
+        @Override
+        public V getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> clazz) {
+            throw new UnsupportedOperationException("not implemented");
+        }
     }
-  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.6</version>
+                <version>2.10</version>
                 <executions>
                     <execution>
                         <phase>install</phase>


### PR DESCRIPTION
Rewrote CacheWriterTest to use same client/server technique for its CacheWriter as CacheLoaderTest did for its CacheLoader.  

Additionally, followed JSR 107 Specification Write-Through Table to ensure that all Cache method interactions with write-through were verified.

Added missing test for partial success for batch mode operations for write-through.  Includes partial success testing for putAll, removeAll and removeAll(Set<K>). 

Fixed javadoc errors in CacheLoader files.

Refactored CacheClient.java to be shared by CacheLoaderClient and CacheWriterClient.

Changed maven-checkstyle-plugin to 2.10.  It was the only way that it could process jdk 1.7 diamond syntax.
(only did this on CacheWriter, did not change any other files to do that).
