### PR TITLE
Reinstate 3 failing CacheExpiryTest after merging outstanding RI pull request 30 (which has fix for failures)

### DIFF
--- a/cache-tests/src/test/java/org/jsr107/tck/expiry/CacheExpiryTest.java
+++ b/cache-tests/src/test/java/org/jsr107/tck/expiry/CacheExpiryTest.java
@@ -887,9 +887,9 @@ public class CacheExpiryTest extends TestSupport {
     recordedExpiryPolicyCallMap.clear();
     resultValue = cache.invoke(key, new GetEntryProcessor<Integer, Integer, Integer>());
     assertEquals(setValue, resultValue);
-    //Fixme Joe - #13 TCK
-    //assertTrue(recordedExpiryPolicyCallMap.containsKey(key));
-    //assertEquals("called getExpiryForAccessedEntry", recordedExpiryPolicyCallMap.get(key));
+
+    assertTrue(recordedExpiryPolicyCallMap.containsKey(key));
+    assertEquals("called getExpiryForAccessedEntry", recordedExpiryPolicyCallMap.get(key));
 
   }
 
@@ -925,11 +925,11 @@ public class CacheExpiryTest extends TestSupport {
 
       // verify create when read through is enabled and entry was non-existent in cache.
       Integer resultValue = cache.invoke(key, new GetEntryProcessor<Integer, Integer, Integer>());
-      // fixme Joe - #13 TCK
-      //assertEquals(recordingCacheLoaderValue, resultValue);
-      //assertTrue(recordingCacheLoader.hasLoaded(key));
-      //assertTrue(recordedExpiryPolicyCallMap.containsKey(key));
-      //assertEquals("called getExpiryForCreatedEntry", recordedExpiryPolicyCallMap.get(key));
+
+      assertEquals(recordingCacheLoaderValue, resultValue);
+      assertTrue(recordingCacheLoader.hasLoaded(key));
+      assertTrue(recordedExpiryPolicyCallMap.containsKey(key));
+      assertEquals("called getExpiryForCreatedEntry", recordedExpiryPolicyCallMap.get(key));
     }
   }
 
@@ -978,11 +978,11 @@ public class CacheExpiryTest extends TestSupport {
 
     // verify accessed
     resultMap = cache.invokeAll(keys, new GetEntryProcessor<Integer, Integer, Integer>());
-    //Fixme Joe - #13 TCK
-//    for (Map.Entry<Integer, Integer> entry : resultMap.entrySet()) {
-//      assertTrue(recordedExpiryPolicyCallMap.containsKey(entry.getKey()));
-//      assertEquals("called getExpiryForAccessedEntry", recordedExpiryPolicyCallMap.get(entry.getKey()));
-//    }
+
+    for (Map.Entry<Integer, Integer> entry : resultMap.entrySet()) {
+      assertTrue(recordedExpiryPolicyCallMap.containsKey(entry.getKey()));
+      assertEquals("called getExpiryForAccessedEntry", recordedExpiryPolicyCallMap.get(entry.getKey()));
+    }
   }
 
   @Test


### PR DESCRIPTION
Must merge following outstanding pull request in RI before merging this pull request into TCK.

https://github.com/jsr107/RI/pull/30

Confirmed that 3 failing tests are failing against current RI and passing vs my outstanding proposed pull request
https://github.com/jsr107/RI/pull/30.  Note that this pull request was requested prior to jsr 107 tck test that required it.
