### PR TITLE
Issue #61 : fix or remove faulty assertions

### DIFF
--- a/cache-tests/src/test/java/org/jsr107/tck/spi/CachingProviderClassLoaderTest.java
+++ b/cache-tests/src/test/java/org/jsr107/tck/spi/CachingProviderClassLoaderTest.java
@@ -75,28 +75,21 @@ public class CachingProviderClassLoaderTest {
     // obtain the default cache manager
     CacheManager manager = provider.getCacheManager();
 
-    assertNotNull(provider);
     assertNotNull(classLoader);
     assertNotNull(manager);
 
     // ensure the default manager is the same as asking the provider
     // for a cache manager using the default URI and classloader
-    assertSame(manager, provider.getCacheManager(provider.getDefaultURI(), classLoader));
+    assertSame(manager, provider.getCacheManager());
+    assertSame(manager, provider.getCacheManager(provider.getDefaultURI(), provider.getDefaultClassLoader()));
 
     // using a different ClassLoader
     ClassLoader otherLoader = new MyClassLoader(classLoader);
     CachingProvider otherProvider = Caching.getCachingProvider(otherLoader);
 
-    // ensure that the providers are different
-    assertNotSame(provider, otherProvider);
-
     CacheManager otherManager = otherProvider.getCacheManager();
-
-    // ensure that the managers are different
-    assertNotSame(manager, otherManager);
-
     assertSame(otherManager, otherProvider.getCacheManager());
-    assertSame(otherManager, otherProvider.getCacheManager(otherProvider.getDefaultURI(), classLoader));
+    assertSame(otherManager, otherProvider.getCacheManager(otherProvider.getDefaultURI(), otherProvider.getDefaultClassLoader()));
   }
 
   /**


### PR DESCRIPTION
I think the fix to Issue 61 was incomplete.  This PR is an attempt to rectify that.  In short I think there are three problems here:

1. The default loader of the Caching class is not necessarily the same as the default loader of a provider that it returns.
2. The spec (at least from my reading) says nothing about:
  * providers looked up using distinct service class loaders being distinct
  * managers loaded with different class loader from distinct or indistinct providers being distinct.

I'm more confident on point 1, than I am on either part of point 2.  If I missed (or misread) something here then let me know and I'll make some revisions.