### PR TITLE
CacheManager.getCacheNames() yields IllegalStateException, if closed

### DIFF
--- a/cache-tests/src/test/java/org/jsr107/tck/CacheManagerTest.java
+++ b/cache-tests/src/test/java/org/jsr107/tck/CacheManagerTest.java
@@ -378,7 +378,7 @@ public class CacheManagerTest extends TestSupport {
     cacheManager.close();
   }
 
-  @Test
+  @Test(expected = IllegalStateException.class)
   public void close_cachesEmpty() {
     CacheManager cacheManager = getCacheManager();
 
@@ -386,7 +386,8 @@ public class CacheManagerTest extends TestSupport {
     cacheManager.createCache("c2", new MutableConfiguration());
 
     cacheManager.close();
-    assertFalse(cacheManager.getCacheNames().iterator().hasNext());
+    cacheManager.getCacheNames();
+    fail();
   }
 
   @Test


### PR DESCRIPTION
Fixes TCK challenge: https://github.com/jsr107/jsr107tck/issues/87
Consequent change in RI: https://github.com/jsr107/RI/issues/48