### PR TITLE
Cleanups in tests

### DIFF
--- a/cache-tests/src/test/java/org/jsr107/tck/event/CacheListenerTest.java
+++ b/cache-tests/src/test/java/org/jsr107/tck/event/CacheListenerTest.java
@@ -43,6 +43,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
 
 import static javax.cache.event.EventType.CREATED;
 import static javax.cache.event.EventType.REMOVED;
@@ -60,6 +61,8 @@ import static org.junit.Assert.fail;
  * @since 1.0
  */
 public class CacheListenerTest extends CacheTestSupport<Long, String> {
+
+  private final Logger logger = Logger.getLogger(getClass().getName());
 
   /**
    * Rule used to exclude tests
@@ -412,7 +415,7 @@ public void testFilteredListener() throws InterruptedException {
   //iterating should cause read events on non-expired entries
   for (Cache.Entry<Long, String> entry : cache) {
     String value = entry.getValue();
-    System.out.println(value);
+    logger.info(value);
   }
   assertEquals(2, filteredListener.getCreated());
   assertEquals(2, filteredListener.getUpdated());

--- a/cache-tests/src/test/java/org/jsr107/tck/expiry/CacheExpiryTest.java
+++ b/cache-tests/src/test/java/org/jsr107/tck/expiry/CacheExpiryTest.java
@@ -978,8 +978,8 @@ public class CacheExpiryTest extends CacheTestSupport<Integer, Integer> {
         };
     Object[] result = (Object[]) cache.invoke(key, new CombineEntryProcessor(processors));
 
-    assertEquals(result[1], setValue);
-    assertEquals(result[2], setValue);
+    assertEquals(setValue, result[1]);
+    assertEquals(setValue, result[2]);
 
     // expiry called should be for create, not for the get or modify.
     // Operations get combined in entry processor and only net result should be expiryPolicy method called.
@@ -1022,9 +1022,9 @@ public class CacheExpiryTest extends CacheTestSupport<Integer, Integer> {
         };
     Object[] result = (Object[]) cache.invoke(key, new CombineEntryProcessor(processors));
 
-    assertEquals(result[1], 111);
-    assertEquals(result[2], setValue);
-    assertEquals(result[3], setValue);
+    assertEquals(111, result[1]);
+    assertEquals(setValue, result[2]);
+    assertEquals(setValue, result[3]);
 
     // expiry called should be for create, not for the get or modify.
     // Operations get combined in entry processor and only net result should be expiryPolicy method called.
@@ -1056,7 +1056,7 @@ public class CacheExpiryTest extends CacheTestSupport<Integer, Integer> {
     // verify access to existing entry.
     resultValue = cache.invoke(key, new SetEntryProcessor<Integer, Integer>(setValue));
 
-    assertEquals(resultValue, setValue);
+    assertEquals(setValue, resultValue);
     assertThat(expiryPolicy.getCreationCount(), greaterThanOrEqualTo(1));
     assertThat(expiryPolicy.getAccessCount(), is(0));
     assertThat(expiryPolicy.getUpdatedCount(), is(0));

--- a/cache-tests/src/test/java/org/jsr107/tck/integration/CacheLoaderTest.java
+++ b/cache-tests/src/test/java/org/jsr107/tck/integration/CacheLoaderTest.java
@@ -289,29 +289,6 @@ public class CacheLoaderTest {
   }
 
   /**
-   * Ensure that a {@link CacheLoader} that returns <code>null</code> entries
-   * aren't placed in the cache.
-   */
-  @Test
-  public void shouldNotLoadNullEntries() {
-    NullValueCacheLoader<String, String> nullCacheLoader = new NullValueCacheLoader<>();
-    cacheLoaderServer.setCacheLoader(nullCacheLoader);
-
-    //construct a set of keys
-    HashSet<String> keys = new HashSet<String>();
-    keys.add("gudday");
-    keys.add("hello");
-    keys.add("howdy");
-    keys.add("bonjour");
-
-    //attempt to get the keys
-    Map<String, String> map = cache.getAll(keys);
-
-    //nothing should have been loaded
-    assertThat(map.size(), is(0));
-  }
-
-  /**
    * Ensure that a {@link CacheLoader} that returns <code>null</code> values
    * aren't placed in the cache.
    */
@@ -858,6 +835,7 @@ public class CacheLoaderTest {
     //wait for the load to complete
     try{
       future.get();
+      fail();
     } catch (ExecutionException e) {
       assertThat(e.getCause(), instanceOf(CacheLoaderException.class));
     }

--- a/cache-tests/src/test/java/org/jsr107/tck/integration/CacheLoaderWithoutReadThroughTest.java
+++ b/cache-tests/src/test/java/org/jsr107/tck/integration/CacheLoaderWithoutReadThroughTest.java
@@ -852,6 +852,7 @@ public class CacheLoaderWithoutReadThroughTest {
     //wait for the load to complete
     try {
       future.get();
+      fail();
     } catch (ExecutionException e) {
       assertThat(e.getCause(), instanceOf(CacheLoaderException.class));
     }

--- a/cache-tests/src/test/java/org/jsr107/tck/integration/CacheLoaderWriterTest.java
+++ b/cache-tests/src/test/java/org/jsr107/tck/integration/CacheLoaderWriterTest.java
@@ -228,33 +228,6 @@ public class CacheLoaderWriterTest {
   }
 
   /**
-   * Ensure that a {@link javax.cache.integration.CacheLoader} that returns <code>null</code> entries
-   * aren't placed in the cache and nothing is written.
-   */
-  @Test
-  public void shouldNotLoadNullEntries() {
-    NullValueCacheLoader<String, String> nullCacheLoader = new NullValueCacheLoader<>();
-    cacheLoaderServer.setCacheLoader(nullCacheLoader);
-
-    //construct a set of keys
-    HashSet<String> keys = new HashSet<String>();
-    keys.add("gudday");
-    keys.add("hello");
-    keys.add("howdy");
-    keys.add("bonjour");
-
-    //attempt to get the keys
-    Map<String, String> map = cache.getAll(keys);
-
-    //nothing should have been loaded
-    assertThat(map.size(), is(0));
-
-    //ensure nothing has been written
-    assertThat(recordingCacheWriter.getWriteCount(), is(0L));
-    assertThat(recordingCacheWriter.getDeleteCount(), is(0L));
-  }
-
-  /**
    * Ensure that a {@link javax.cache.integration.CacheLoader} that returns <code>null</code> values
    * aren't placed in the cache or written
    */

--- a/cache-tests/src/test/java/org/jsr107/tck/integration/CacheWriterTest.java
+++ b/cache-tests/src/test/java/org/jsr107/tck/integration/CacheWriterTest.java
@@ -503,8 +503,8 @@ public class CacheWriterTest extends TestSupport {
         };
     Object[] result = cache.invoke(1, new CombineEntryProcessor<Integer, String>(processors));
 
-    assertEquals(result[1], "Gudday World");
-    assertEquals(result[1], cache.get(1));
+    assertEquals("Gudday World", result[1]);
+    assertEquals(cache.get(1), result[1]);
     assertEquals(cache.get(1), cacheWriter.get(1));
     assertEquals(1, cacheWriter.getWriteCount());
     assertEquals(0, cacheWriter.getDeleteCount());

--- a/cache-tests/src/test/java/org/jsr107/tck/management/CacheMBStatisticsBeanTest.java
+++ b/cache-tests/src/test/java/org/jsr107/tck/management/CacheMBStatisticsBeanTest.java
@@ -389,7 +389,7 @@ public class CacheMBStatisticsBeanTest extends CacheTestSupport<Long, String> {
     //non-existent key. cache miss.
     cache.invoke(1000l, new NoOpEntryProcessor<Long, String>());
 
-    assertEquals(result, "Sooty");
+    assertEquals("Sooty", result);
     assertEquals(2L, lookupManagementAttribute(cache, CacheStatistics, "CacheHits"));
     assertThat((Float) lookupManagementAttribute(cache, CacheStatistics, "CacheHitPercentage"), greaterThanOrEqualTo(66.65f));
     assertEquals(1L, lookupManagementAttribute(cache, CacheStatistics, "CacheMisses"));
@@ -408,7 +408,7 @@ public class CacheMBStatisticsBeanTest extends CacheTestSupport<Long, String> {
 
     cache.put(1l, "Sooty");
     String result = cache.invoke(1l, new SetEntryProcessor<Long, String>("Trinity"));
-    assertEquals(result, "Trinity");
+    assertEquals("Trinity", result);
     assertEquals(1L, lookupManagementAttribute(cache, CacheStatistics, "CacheHits"));
     assertEquals(100.0f, lookupManagementAttribute(cache, CacheStatistics, "CacheHitPercentage"));
     assertEquals(0L, lookupManagementAttribute(cache, CacheStatistics, "CacheMisses"));
@@ -426,7 +426,7 @@ public class CacheMBStatisticsBeanTest extends CacheTestSupport<Long, String> {
 
     cache.put(1l, "Sooty");
     String result = cache.invoke(1l, new RemoveEntryProcessor<Long, String, String>(true));
-    assertEquals(result, "Sooty");
+    assertEquals("Sooty", result);
     assertEquals(1L, lookupManagementAttribute(cache, CacheStatistics, "CacheHits"));
     assertEquals(100.0f, lookupManagementAttribute(cache, CacheStatistics, "CacheHitPercentage"));
     assertEquals(0L, lookupManagementAttribute(cache, CacheStatistics, "CacheMisses"));


### PR DESCRIPTION
- use logger instead of System.out
- fix reversed assertEquals
- remove duplicate tests
- add missing fail() statements

Fixes #105 