### PR TITLE
[Rebased] Check for close() is called when Customization implement Closable

### DIFF
--- a/cache-tests/checkstyle/suppressions.xml
+++ b/cache-tests/checkstyle/suppressions.xml
@@ -16,4 +16,7 @@
     <!--Exclude Clover instrumented sources-->
     <suppress checks="" files="[\\/]src-instrumented[\\/]"/>
 
+    <!-- Exclude files with additional copyright notices -->
+    <suppress checks="Header" files="Server.java" />
+
 </suppressions>

--- a/cache-tests/src/main/java/org/jsr107/tck/support/CacheClient.java
+++ b/cache-tests/src/main/java/org/jsr107/tck/support/CacheClient.java
@@ -6,6 +6,7 @@
  */
 package org.jsr107.tck.support;
 
+import java.io.Closeable;
 import java.io.Serializable;
 import java.net.InetAddress;
 
@@ -15,7 +16,7 @@ import java.net.InetAddress;
  * @author Brian Oliver
  * @author Joe Fialli
  */
-public class CacheClient implements AutoCloseable, Serializable {
+public class CacheClient implements Closeable, Serializable {
     /**
      * The {@link java.net.InetAddress} on which to connect to the {@link org.jsr107.tck.integration.CacheLoaderServer}.
      */
@@ -60,9 +61,10 @@ public class CacheClient implements AutoCloseable, Serializable {
      * {@inheritDoc}
      */
     @Override
-    public synchronized void close() throws Exception {
+    public synchronized void close() {
         if (client != null) {
             try {
+                client.invoke(Server.CLOSE_OPERATION);
                 client.close();
             } finally {
                 client = null;

--- a/cache-tests/src/main/java/org/jsr107/tck/support/Server.java
+++ b/cache-tests/src/main/java/org/jsr107/tck/support/Server.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright (c) 2011-2016 Terracotta, Inc.
  *  Copyright (c) 2011-2016 Oracle and/or its affiliates.
+ *  Copyright (c) 2016 headissue GmbH
  *
  *  All rights reserved. Use is subject to license terms.
  */
@@ -30,6 +31,7 @@ import java.util.logging.Logger;
  * {@link Client}s.
  *
  * @author Brian Oliver
+ * @author Jens Wilke
  * @see Client
  * @see Operation
  * @see OperationHandler

--- a/cache-tests/src/main/java/org/jsr107/tck/support/Server.java
+++ b/cache-tests/src/main/java/org/jsr107/tck/support/Server.java
@@ -217,7 +217,7 @@ public class Server implements AutoCloseable {
             if (clientConnections.size() > 0) {
                 LOG.warning("Open client connections: " + clientConnections);
                 throw new IllegalStateException(
-                  "Excepting no open client connections. " +
+                  "Expecting no open client connections. " +
                   "Customizations implementing Closeable need to be closed. " +
                   "See https://github.com/jsr107/jsr107tck/issues/100"
                 );

--- a/cache-tests/src/main/java/org/jsr107/tck/support/Server.java
+++ b/cache-tests/src/main/java/org/jsr107/tck/support/Server.java
@@ -6,6 +6,7 @@
  */
 package org.jsr107.tck.support;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -40,6 +41,35 @@ public class Server implements AutoCloseable {
      */
     public static final  Logger LOG = Logger.getLogger(Server.class.getName());
 
+    /**
+     * Special operation to signal the server that the client has been closed.
+     */
+    public static final Operation<Void> CLOSE_OPERATION = new Operation<Void>() {
+        @Override
+        public String getType() {
+            return "CLOSE";
+        }
+
+      /**
+       * The connections are closed by the server upon receiving the closed operation.
+       * We need to block in the client until the server performed the close, to make
+       * sure the server has removed the client from the client collection map.
+       *
+       * <p>This is executed in the client after the close command is sent.
+       *
+       * @see Client#invoke(Operation)
+       */
+        @Override
+        public Void onInvoke(final ObjectInputStream ois, final ObjectOutputStream oos) throws IOException {
+            try {
+                ois.readByte();
+                throw new IOException("Unexpected data received from the server after close.");
+            } catch (EOFException expected) {
+                // connection successfully closed by the server
+            }
+            return null;
+        }
+    };
 
     /**
      * The port on which the {@link Server} will accept {@link Client} connections.
@@ -182,6 +212,15 @@ public class Server implements AutoCloseable {
             //we're now terminating
             isTerminating.set(true);
 
+            if (clientConnections.size() > 0) {
+                LOG.warning("Open client connections: " + clientConnections);
+                throw new IllegalStateException(
+                  "Excepting no open client connections. " +
+                  "Customizations implementing Closeable need to be closed. " +
+                  "See https://github.com/jsr107/jsr107tck/issues/100"
+                );
+            }
+
             //stop the server socket
             try {
                 serverSocket.close();
@@ -254,6 +293,15 @@ public class Server implements AutoCloseable {
                 while (true) {
                     try {
                         String operation = (String) ois.readObject();
+                        if (CLOSE_OPERATION.getType().equals(operation)) {
+                            // regular close, remove before closing
+                            Server.this.clientConnections.remove(identity);
+                            // connection close means we acknowledge to the client and the client may
+                            // complete the close operation.
+                            socket.close();
+                            socket = null;
+                            break;
+                        }
                         OperationHandler handler = Server.this.operationHandlers.get(operation);
 
                         if (handler != null) {

--- a/cache-tests/src/test/java/org/jsr107/tck/expiry/CacheExpiryTest.java
+++ b/cache-tests/src/test/java/org/jsr107/tck/expiry/CacheExpiryTest.java
@@ -791,6 +791,8 @@ public class CacheExpiryTest extends CacheTestSupport<Integer, Integer> {
         assertThat(recordingCacheLoader.hasLoaded(key), is(true));
         assertThat(cache.get(key), is(equalTo(key)));
       }
+
+      closeTestCache();
     }
   }
 
@@ -1107,6 +1109,8 @@ public class CacheExpiryTest extends CacheTestSupport<Integer, Integer> {
       assertThat(expiryPolicy.getCreationCount(), greaterThanOrEqualTo(1));
       assertThat(expiryPolicy.getAccessCount(), is(0));
       assertThat(expiryPolicy.getUpdatedCount(), is(0));
+
+      closeTestCache();
     }
   }
 
@@ -1198,7 +1202,17 @@ public class CacheExpiryTest extends CacheTestSupport<Integer, Integer> {
       assertThat(expiryPolicy.getAccessCount(), is(0));
       assertThat(expiryPolicy.getUpdatedCount(), is(0));
       expiryPolicy.resetCount();
+
+      closeTestCache();
     }
+  }
+
+  /**
+   * Helper method for all tests that define an extra cache loader. The cache needs to be closed
+   * before the server is close, since the server asserts that all clients have been closed correctly.
+   */
+  private void closeTestCache() {
+    getCacheManager().destroyCache(getTestCacheName());
   }
 
   @Test

--- a/cache-tests/src/test/java/org/jsr107/tck/integration/CacheLoaderClientServerTest.java
+++ b/cache-tests/src/test/java/org/jsr107/tck/integration/CacheLoaderClientServerTest.java
@@ -83,18 +83,15 @@ public class CacheLoaderClientServerTest {
    *
    * @see <a href="https://github.com/jsr107/jsr107tck/issues/100">Customizations may implement Closeable</a>
    */
-  @Test
+  @Test(expected = IllegalStateException.class)
   public void clientMustBeClosedBeforeServer() throws Exception {
     NullValueCacheLoader<String, String> nullCacheLoader = new NullValueCacheLoader<>();
     CacheLoaderServer<String, String> serverCacheLoader = new CacheLoaderServer<String, String>(10000, nullCacheLoader);
     serverCacheLoader.open();
     CacheLoaderClient<String, String> clientCacheLoader = new CacheLoaderClient<>(serverCacheLoader.getInetAddress(), serverCacheLoader.getPort());
     clientCacheLoader.load("hi");
-    try {
-      serverCacheLoader.close();
-    } catch (IllegalStateException e) {
-      // expected
-    }
+    // server will throw IllegalStateException due to existence of client that was not closed
+    serverCacheLoader.close();
   }
 
 }

--- a/cache-tests/src/test/java/org/jsr107/tck/integration/CacheWriterClientServerTest.java
+++ b/cache-tests/src/test/java/org/jsr107/tck/integration/CacheWriterClientServerTest.java
@@ -28,91 +28,46 @@ public class CacheWriterClientServerTest {
      * the {@link CacheWriterServer}.
      */
     @Test
-    public void shouldWriteFromServerWithClient() {
+    public void shouldWriteFromServerWithClient() throws Exception {
 
         RecordingCacheWriter<String, String> recordingCacheWriter = new RecordingCacheWriter<>();
 
         CacheWriterServer<String, String> serverCacheWriter = new CacheWriterServer<>(10000,
                                                                   recordingCacheWriter);
-
-        try {
-            serverCacheWriter.open();
-
-            CacheWriterClient<String, String> clientCacheWriter =
-                new CacheWriterClient<>(serverCacheWriter.getInetAddress(), serverCacheWriter.getPort());
-            Cache.Entry<String, String> entry = new Entry<>("hello", "gudday");
-            clientCacheWriter.write(entry);
-            String writtenValue = recordingCacheWriter.get("hello");
-
-            Assert.assertThat(writtenValue, is(notNullValue()));
-            Assert.assertThat(writtenValue, is("gudday"));
-            Assert.assertThat(recordingCacheWriter.hasWritten("hello"), is(true));
-        } catch (Exception e) {}
-        finally {
-            serverCacheWriter.close();
-        }
+        serverCacheWriter.open();
+        CacheWriterClient<String, String> clientCacheWriter =
+            new CacheWriterClient<>(serverCacheWriter.getInetAddress(), serverCacheWriter.getPort());
+        Cache.Entry<String, String> entry = new Entry<>("hello", "gudday");
+        clientCacheWriter.write(entry);
+        String writtenValue = recordingCacheWriter.get("hello");
+        Assert.assertThat(writtenValue, is(notNullValue()));
+        Assert.assertThat(writtenValue, is("gudday"));
+        Assert.assertThat(recordingCacheWriter.hasWritten("hello"), is(true));
+        clientCacheWriter.close();
+        serverCacheWriter.close();
     }
 
     /**
      * Ensure that exceptions thrown by an underlying cache Writer are re-thrown.
      */
     @Test
-    public void shouldRethrowExceptions() {
-
+    public void shouldRethrowExceptions() throws Exception {
         FailingCacheWriter<String, String> failingCacheWriter = new FailingCacheWriter<>();
-
         CacheWriterServer<String, String> serverCacheWriter = new CacheWriterServer<>(10000,
                                                                   failingCacheWriter);
-
+        serverCacheWriter.open();
+        CacheWriterClient<String, String> clientCacheWriter =
+            new CacheWriterClient<>(serverCacheWriter.getInetAddress(), serverCacheWriter.getPort());
+        Cache.Entry<String, String> entry = new Entry<>("hello", "gudday");
         try {
-            serverCacheWriter.open();
-
-            CacheWriterClient<String, String> clientCacheWriter =
-                new CacheWriterClient<>(serverCacheWriter.getInetAddress(), serverCacheWriter.getPort());
-
-            Cache.Entry<String, String> entry = new Entry<>("hello", "gudday");
-
             clientCacheWriter.write(entry);
-
             fail("An UnsupportedOperationException should have been thrown");
-        } catch (Exception e) {}
-        finally {
-            serverCacheWriter.close();
+        } catch (UnsupportedOperationException e) {
+            // expected
         }
+        clientCacheWriter.close();
+        serverCacheWriter.close();
     }
-
-    /**
-     * Ensure that <code>null</code> entries can be passed from the
-     * {@link CacheWriterServer} back to the {@link CacheWriterClient}.
-     */
-
-    /*
-     * @Test
-     * public void shouldLoadNullEntriesFromServerWithClient() {
-     *
-     *   NullEntryCacheWriter<String, String> nullCacheWriter = new NullEntryCacheWriter<>();
-     *
-     *   CacheWriterServer<String, String> serverCacheWriter =
-     *   new CacheWriterServer<String, String>(10000, nullCacheWriter);
-     *
-     *   try {
-     *       serverCacheWriter.open();
-     *
-     *       CacheWriterClient<String, String> clientCacheWriter =
-     *       new CacheWriterClient<>(serverCacheWriter.getInetAddress(), serverCacheWriter.getPort());
-     *
-     *       Cache.Entry<String, String> entry = new Entry<String,String>("hello", "gudday");
-     *
-     *       Cache.Entry<String, String> entry = clientCacheWriter.write(entry);
-     *
-     *       Assert.assertThat(entry, is(nullValue()));
-     *   } catch (Exception e) {
-     *
-     *   } finally {
-     *       serverCacheWriter.close();
-     *   }
-     * }
-     */
 
     private static class Entry<K, V> implements Cache.Entry<K, V> {
         private K key;
@@ -125,12 +80,12 @@ public class CacheWriterClientServerTest {
 
         @Override
         public K getKey() {
-            throw new UnsupportedOperationException("not implemented");
+            return key;
         }
 
         @Override
         public V getValue() {
-            throw new UnsupportedOperationException("not implemented");
+            return value;
         }
 
         @Override


### PR DESCRIPTION
Rebased #106 with some additional minor fixes:
* Fixed `CacheLoaderClientServerTest#clientMustBeClosedBeforeServer` to expect an `IllegalStateException` (with previous idiom, a `fail()` was missing after `serverCacheLoader.close();`)
* Added `Server.java` to checkstyle suppresions (copyright in this file was updated in rebased commits)
* A minor typo was fixed