### PR TITLE
Assert properties used to create CacheManager are returned from CacheManager.getProperties()

### DIFF
--- a/cache-tests/src/test/java/org/jsr107/tck/CachingTest.java
+++ b/cache-tests/src/test/java/org/jsr107/tck/CachingTest.java
@@ -91,10 +91,10 @@ public class CachingTest {
     }
     CachingProvider provider = Caching.getCachingProvider();
     Properties properties = new Properties();
-    properties.put("dummy.com", "goofy");
+    properties.setProperty("javax.cache.test.1", "value1");
     provider.getCacheManager(provider.getDefaultURI(), provider.getDefaultClassLoader(), properties);
     CacheManager manager = provider.getCacheManager();
-    assertEquals(properties, manager.getProperties());
+    assertEquals("value1", manager.getProperties().getProperty("javax.cache.test.1"));
   }
 
   /**


### PR DESCRIPTION
`CachingTest.getCacheManager_nonNullProperties` should assert that a property that was provided when creating the `CacheManager` is returned by `CacheManager.getProperties()`, instead of asserting `Properties` object equality as discussed in https://github.com/jsr107/jsr107tck/issues/102#issuecomment-267596515

Fixes #102