### PR TITLE
Allow cache implementations to wrap the EntryProcessorException

### DIFF
--- a/cache-tests/src/test/java/org/jsr107/tck/processor/CacheInvokeTest.java
+++ b/cache-tests/src/test/java/org/jsr107/tck/processor/CacheInvokeTest.java
@@ -202,8 +202,9 @@ public class CacheInvokeTest extends CacheTestSupport<Integer, String> {
       cache.invoke(key, new CombineEntryProcessor(processors));
       fail();
     } catch (CacheException e) {
-      assertTrue("expected IllegalAccessError; observed " + e.getCause(),
-          e.getCause() instanceof IllegalAccessError);
+      Throwable rootCause = getRootCause(e);
+      assertTrue("expected IllegalAccessError; observed " + rootCause,
+          rootCause instanceof IllegalAccessError);
     }
     assertFalse(cache.containsKey(key));
   }
@@ -230,6 +231,13 @@ public class CacheInvokeTest extends CacheTestSupport<Integer, String> {
     assertEquals(newValue, cache.get(key));
   }
 
+  private static Throwable getRootCause(Throwable t) {
+    if (t.getCause() == null) {
+      return t;
+    }
+    return getRootCause(t.getCause());
+  }
+
   @Test
   public void existingException() {
     final Integer key = 123;
@@ -246,8 +254,9 @@ public class CacheInvokeTest extends CacheTestSupport<Integer, String> {
       cache.invoke(key, new CombineEntryProcessor<Integer, String>(processors));
       fail();
     } catch (CacheException e) {
-      assertTrue("expected IllegalAccessError; observed " + e.getCause(),
-          e.getCause() instanceof IllegalAccessError);
+      Throwable rootCause = getRootCause(e);
+      assertTrue("expected IllegalAccessError; observed " + rootCause,
+         rootCause instanceof IllegalAccessError);
     }
     assertEquals(oldValue, cache.get(key));
   }
@@ -287,8 +296,9 @@ public class CacheInvokeTest extends CacheTestSupport<Integer, String> {
       cache.invoke(key, new ThrowExceptionEntryProcessor<Integer, String, Void>(IllegalAccessError.class));
       fail();
     } catch (CacheException e) {
-      assertTrue("expected IllegalAccessError; observed " + e.getCause(),
-          e.getCause() instanceof IllegalAccessError);
+      Throwable t = getRootCause(e);
+      assertTrue("expected IllegalAccessError; observed " + t,
+          t instanceof IllegalAccessError);
     }
     assertEquals(oldValue, cache.get(key));
   }


### PR DESCRIPTION
Pull request for #85 