### PR TITLE
Update listener tests according to CacheEntryEvent.getOldValue spec clarifications

### DIFF
--- a/cache-tests/src/main/java/org/jsr107/tck/event/CacheEntryListenerClient.java
+++ b/cache-tests/src/main/java/org/jsr107/tck/event/CacheEntryListenerClient.java
@@ -113,29 +113,20 @@ public class CacheEntryListenerClient<K, V> extends CacheClient
         // Serialize rest of CacheEntryEvent
         oos.writeObject(event.getKey());
         oos.writeObject(event.getValue());
-
-        // commented out since there is an issue with working
-        // with these next 2 fields.
-        // be sure to read these in TestCacheEntryEvent.readObject
-        // when trying to reinstate them.
-        /*
+        oos.writeObject(event.getOldValue());
         oos.writeBoolean(event.isOldValueAvailable());
-        if (event.isOldValueAvailable()) {
-          Object oldValue = null;
-          try {
-            oldValue = event.getOldValue();
-          } catch (Throwable t) {
-            t.printStackTrace();
-          }
-          oos.writeObject(oldValue);
-        }
-        */
+        // ensure everything is written to the stream before blocking, waiting for a result
+        oos.flush();
+
         result = ois.readObject();
       } catch (Throwable t) {
         t.printStackTrace();
       }
       if (result instanceof CacheEntryListenerException) {
         throw ((CacheEntryListenerException)result);
+      }
+      if (result instanceof AssertionError) {
+        throw ((AssertionError) result);
       }
 
       // nothing to return.

--- a/cache-tests/src/main/java/org/jsr107/tck/event/TestCacheEntryEvent.java
+++ b/cache-tests/src/main/java/org/jsr107/tck/event/TestCacheEntryEvent.java
@@ -76,6 +76,8 @@ public class TestCacheEntryEvent<K, V> extends CacheEntryEvent<K, V> {
     try {
       key = (K) ois.readObject();
       value = (V) ois.readObject();
+      oldValue = (V) ois.readObject();
+      isOldValueAvailable = ois.readBoolean();
 
       // problem dealing with the next 2 fields of CacheEntryEvent.
       // comment out for now.

--- a/cache-tests/src/test/java/org/jsr107/tck/expiry/CacheExpiryTest.java
+++ b/cache-tests/src/test/java/org/jsr107/tck/expiry/CacheExpiryTest.java
@@ -101,7 +101,7 @@ public class CacheExpiryTest extends CacheTestSupport<Integer, Integer> {
 
   @Override
   protected MutableConfiguration<Integer, Integer> extraSetup(MutableConfiguration<Integer, Integer> configuration) {
-    listener = new CacheTestSupport.MyCacheEntryListener<Integer, Integer>();
+    listener = new CacheTestSupport.MyCacheEntryListener<Integer, Integer>(true);
 
     //establish a CacheEntryListenerClient that a Cache can use for CacheEntryListening
     //(via the CacheEntryListenerServer)


### PR DESCRIPTION
Fixes client-server listeners test infrastructure to propagate AssertionErrors. Otherwise assertions from `CacheEntryListener`s are silently swallowed.

Also updates CacheListenerTest as parameterized test to assert old value availability when old value required is `true` or `false`.

Depends on https://github.com/jsr107/jsr107spec/pull/392 , part of fix for https://github.com/jsr107/jsr107spec/pull/391