### PR TITLE
These fields should be final or volatile to insure visibility from other threads

### DIFF
--- a/cache-tests/src/main/java/org/jsr107/tck/integration/CacheLoaderServer.java
+++ b/cache-tests/src/main/java/org/jsr107/tck/integration/CacheLoaderServer.java
@@ -29,7 +29,7 @@ public class CacheLoaderServer<K, V> extends Server {
    * The underlying {@link CacheLoader} that will be used to
    * load entries requested by the {@link CacheLoaderClient}s.
    */
-  private CacheLoader<K, V> cacheLoader;
+  private volatile CacheLoader<K, V> cacheLoader;
 
   /**
    * Constructs an {@link CacheLoaderServer} (without a {@link CacheLoader} to

--- a/cache-tests/src/main/java/org/jsr107/tck/integration/RecordingCacheLoader.java
+++ b/cache-tests/src/main/java/org/jsr107/tck/integration/RecordingCacheLoader.java
@@ -28,12 +28,12 @@ public class RecordingCacheLoader<K> implements CacheLoader<K, K>, AutoCloseable
   /**
    * The keys that have been loaded by this loader.
    */
-  private ConcurrentHashMap<K, K> loaded = new ConcurrentHashMap<K, K>();
+  private final ConcurrentHashMap<K, K> loaded = new ConcurrentHashMap<K, K>();
 
   /**
    * The number of loads that have occurred.
    */
-  private AtomicInteger loadCount = new AtomicInteger(0);
+  private final AtomicInteger loadCount = new AtomicInteger(0);
 
   /**
    * {@inheritDoc}

--- a/cache-tests/src/main/java/org/jsr107/tck/support/Server.java
+++ b/cache-tests/src/main/java/org/jsr107/tck/support/Server.java
@@ -107,7 +107,7 @@ public class Server implements AutoCloseable {
     /**
      * Should the running {@link Server} terminate as soon as possible?
      */
-    private AtomicBoolean isTerminating;
+    private final AtomicBoolean isTerminating;
 
     /**
      * Construct a {@link Server} that will accept {@link Client} connections


### PR DESCRIPTION
I did a quick look and they do not seem to be properly synchronized so the final or volatile is required.

In any case, it's not harmful.