### PR TITLE
Fix element name in specific-implementation-tester POM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@
 *.iws
 .idea
 target
-/.settings
-/.project
-/.classpath
+.settings/
+.project
+.classpath

--- a/implementation-tester/specific-implementation-tester/pom.xml
+++ b/implementation-tester/specific-implementation-tester/pom.xml
@@ -129,7 +129,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <excludes>
-                                <include>**/interceptor/*Test.java</include>
+                                <exclude>**/interceptor/*Test.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
The PR also contains commit for fixing Eclipse IDE expressions in `.gitignore`.