### PR TITLE
Fixes javadoc generation when using JDK >= 10 to build JCache

### DIFF
--- a/implementation-tester/specific-implementation-tester/pom.xml
+++ b/implementation-tester/specific-implementation-tester/pom.xml
@@ -129,7 +129,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <excludes>
-                                <include>**/interceptor/*Test.java</include>
+                                <exclude>**/interceptor/*Test.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0-M1</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
Upgrades maven-javadoc-plugin to 3.0.1 which includes a fix for
newer JDKs.
Also fixes `excludes` filter in `specific-implementation-tester`.

Part of fixes for https://github.com/jsr107/jsr107spec/issues/404